### PR TITLE
Set colorMode preference to light

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -3,6 +3,9 @@ export default defineNuxtConfig({
   compatibilityDate: '2024-04-03',
   devtools: { enabled: true },
   modules: ['@nuxt/ui', '@nuxtjs/tailwindcss', '@nuxt/fonts'],
+  colorMode: {
+    preference: 'light'
+  },
   css: ['@/assets/styles.scss', 'tailwindcss/tailwind.css'], // Tailwind last
   tailwindcss: {
     configPath: './tailwind.config.js',


### PR DESCRIPTION
This deactivates dark mode by explicitly setting the `colorMode` `preference` to `light`.
Dark mode can be a feature in the future, but for the time being, we're keeping things simple and going with one (light) colour mode.