### PR TITLE
Handle failed IP fetch gracefully

### DIFF
--- a/frontend/pages/search.vue
+++ b/frontend/pages/search.vue
@@ -162,9 +162,19 @@ async function fetchSearchResults(query, filters) {
     const userHost = window.location.hostname
 
     // Fetch user's IP address
-    const ipResponse = await fetch('https://api.ipify.org?format=json')
-    const ipData = await ipResponse.json()
-    const userIp = ipData.ip
+    let userIp = 'Unknown'
+    try {
+      const ipResponse = await fetch('https://api.ipify.org?format=json')
+      const ipData = await ipResponse.json()
+      if (ipData.ip) {
+        userIp = ipData.ip
+      }
+    } catch (error) {
+      console.warn('Could not fetch IP address:', error)
+    }
+
+    // Add IP to request body safely
+    requestBody.ip_address = userIp
 
     // Fetch detailed user info (browser, platform, etc.)
     const userInfo = await fetchUserInfo()


### PR DESCRIPTION
- Wrapped `api.ipify.org` request in a try-catch block
- If the IP fetch fails, fallback to `"Unknown"` instead of breaking the function
- Added console warning for debugging when IP retrieval fails
- Ensured search requests continue even if IP retrieval is unsuccessful