### PR TITLE
fix: map warnings

### DIFF
--- a/frontend/components/maps/MapAfrica.vue
+++ b/frontend/components/maps/MapAfrica.vue
@@ -30,8 +30,8 @@
       ]"
       :fill="true"
       color="white"
-      weight="0"
-      fill-opacity="1"
+      :weight="0"
+      :fill-opacity="1"
     />
     <!-- GeoJSON Layer -->
     <LGeoJson

--- a/frontend/components/maps/MapAllRegions.vue
+++ b/frontend/components/maps/MapAllRegions.vue
@@ -30,8 +30,8 @@
       ]"
       :fill="true"
       color="white"
-      weight="0"
-      fill-opacity="1"
+      :weight="0"
+      :fill-opacity="1"
     />
     <!-- GeoJSON Layer -->
     <LGeoJson

--- a/frontend/components/maps/MapArabStates.vue
+++ b/frontend/components/maps/MapArabStates.vue
@@ -30,8 +30,8 @@
       ]"
       :fill="true"
       color="white"
-      weight="0"
-      fill-opacity="1"
+      :weight="0"
+      :fill-opacity="1"
     />
     <!-- GeoJSON Layer -->
     <LGeoJson

--- a/frontend/components/maps/MapAsiaPacific.vue
+++ b/frontend/components/maps/MapAsiaPacific.vue
@@ -30,8 +30,8 @@
       ]"
       :fill="true"
       color="white"
-      weight="0"
-      fill-opacity="1"
+      :weight="0"
+      :fill-opacity="1"
     />
     <!-- GeoJSON Layer -->
     <LGeoJson

--- a/frontend/components/maps/MapEurope.vue
+++ b/frontend/components/maps/MapEurope.vue
@@ -30,8 +30,8 @@
       ]"
       :fill="true"
       color="white"
-      weight="0"
-      fill-opacity="1"
+      :weight="0"
+      :fill-opacity="1"
     />
     <!-- GeoJSON Layer -->
     <LGeoJson

--- a/frontend/components/maps/MapMiddleEast.vue
+++ b/frontend/components/maps/MapMiddleEast.vue
@@ -30,8 +30,8 @@
       ]"
       :fill="true"
       color="white"
-      weight="0"
-      fill-opacity="1"
+      :weight="0"
+      :fill-opacity="1"
     />
     <!-- GeoJSON Layer -->
     <LGeoJson

--- a/frontend/components/maps/MapNorthAmerica.vue
+++ b/frontend/components/maps/MapNorthAmerica.vue
@@ -30,8 +30,8 @@
       ]"
       :fill="true"
       color="white"
-      weight="0"
-      fill-opacity="1"
+      :weight="0"
+      :fill-opacity="1"
     />
     <!-- GeoJSON Layer -->
     <LGeoJson

--- a/frontend/components/maps/MapSouthLatinAmerica.vue
+++ b/frontend/components/maps/MapSouthLatinAmerica.vue
@@ -30,8 +30,8 @@
       ]"
       :fill="true"
       color="white"
-      weight="0"
-      fill-opacity="1"
+      :weight="0"
+      :fill-opacity="1"
     />
     <!-- GeoJSON Layer -->
     <LGeoJson


### PR DESCRIPTION
Update properties to use v-bind syntax for weight and fill-opacity in the GeoJSON Layer to resolve mapping warnings.