### PR TITLE
fix(ui): add error handling to components missing error states

### DIFF
--- a/frontend/components/case-analyzer/JurisdictionConfirmCard.vue
+++ b/frontend/components/case-analyzer/JurisdictionConfirmCard.vue
@@ -24,7 +24,14 @@
       </UFormGroup>
 
       <UFormGroup label="Jurisdiction">
+        <div v-if="jurisdictionsLoading" class="text-sm text-gray-500">
+          Loading jurisdictions...
+        </div>
+        <div v-else-if="jurisdictionsError" class="text-sm text-gray-500">
+          Failed to load jurisdictions
+        </div>
         <JurisdictionSelectMenu
+          v-else
           :model-value="selectedJurisdiction"
           :countries="jurisdictions || []"
           placeholder="Select jurisdiction"
@@ -67,7 +74,11 @@ import JurisdictionSelectMenu from "@/components/jurisdiction-comparison/Jurisdi
 import DocumentDisplay from "@/components/case-analyzer/DocumentDisplay.vue";
 import { useJurisdictions } from "@/composables/useJurisdictions";
 
-const { data: jurisdictions } = useJurisdictions();
+const {
+  data: jurisdictions,
+  isLoading: jurisdictionsLoading,
+  error: jurisdictionsError,
+} = useJurisdictions();
 
 const props = defineProps<{
   documentName: string;

--- a/frontend/components/content/JurisdictionQuestions.vue
+++ b/frontend/components/content/JurisdictionQuestions.vue
@@ -42,7 +42,10 @@
             <LoadingBar />
           </div>
 
-          <InlineError v-else-if="jurisdictionsError" />
+          <InlineError
+            v-else-if="jurisdictionsError"
+            :error="jurisdictionsError"
+          />
 
           <div v-else class="flex flex-col gap-4 md:flex-row md:items-center">
             <JurisdictionSelectMenu
@@ -65,7 +68,10 @@
         <LoadingBar />
       </div>
 
-      <InlineError v-else-if="questionsError || answersError" />
+      <InlineError
+        v-else-if="questionsError || answersError"
+        :error="questionsError || answersError"
+      />
 
       <div v-else-if="isSingleJurisdiction" class="divide-y divide-gray-100">
         <div
@@ -290,6 +296,7 @@ import {
 import { useJurisdictions } from "@/composables/useJurisdictions";
 import JurisdictionSelectMenu from "@/components/jurisdiction-comparison/JurisdictionSelectMenu.vue";
 import LoadingBar from "@/components/layout/LoadingBar.vue";
+import InlineError from "@/components/ui/InlineError.vue";
 import type { JurisdictionOption } from "@/types/analyzer";
 
 // Props - now only needs the primary jurisdiction

--- a/frontend/components/landing-page/LeadingCases.vue
+++ b/frontend/components/landing-page/LeadingCases.vue
@@ -8,7 +8,7 @@
       <div v-if="isLoading">
         <LoadingLandingPageCard />
       </div>
-      <InlineError v-else-if="error" />
+      <InlineError v-else-if="error" :error="error" />
       <template v-else-if="leadingCases">
         <div class="flex w-full flex-col gap-2">
           <NuxtLink
@@ -42,7 +42,7 @@
 
 <script setup>
 import LoadingLandingPageCard from "@/components/layout/LoadingLandingPageCard.vue";
-
+import InlineError from "@/components/ui/InlineError.vue";
 import { useLeadingCases } from "@/composables/useFullTable";
 import { formatYear } from "@/utils/format";
 

--- a/frontend/components/landing-page/PlotCourtDecisionsJurisdiction.vue
+++ b/frontend/components/landing-page/PlotCourtDecisionsJurisdiction.vue
@@ -9,7 +9,7 @@
       <LoadingLandingPageCard />
     </div>
 
-    <InlineError v-else-if="error" />
+    <InlineError v-else-if="error" :error="error" />
 
     <div v-else-if="data && chartData.length > 0" class="chart-container">
       <div class="chart-bars">
@@ -46,6 +46,7 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
 import LoadingLandingPageCard from "@/components/layout/LoadingLandingPageCard.vue";
+import InlineError from "@/components/ui/InlineError.vue";
 import {
   useJurisdictionChart,
   useJurisdictions,

--- a/frontend/components/landing-page/RecentDomesticInstruments.vue
+++ b/frontend/components/landing-page/RecentDomesticInstruments.vue
@@ -16,7 +16,7 @@
       <div v-if="isLoading">
         <LoadingLandingPageCard />
       </div>
-      <InlineError v-else-if="error" />
+      <InlineError v-else-if="error" :error="error" />
       <template v-else-if="domesticInstruments">
         <div class="flex w-full flex-col gap-2">
           <NuxtLink
@@ -50,6 +50,7 @@
 
 <script setup>
 import LoadingLandingPageCard from "@/components/layout/LoadingLandingPageCard.vue";
+import InlineError from "@/components/ui/InlineError.vue";
 import { useDomesticInstruments } from "@/composables/useDomesticInstruments";
 import { formatYear } from "@/utils/format";
 

--- a/frontend/components/landing-page/SuccessfulLegalTransplantations.vue
+++ b/frontend/components/landing-page/SuccessfulLegalTransplantations.vue
@@ -10,7 +10,7 @@
       <div v-if="isLoading">
         <LoadingLandingPageCard />
       </div>
-      <InlineError v-else-if="error" />
+      <InlineError v-else-if="error" :error="error" />
       <template v-else-if="domesticInstruments">
         <div class="flex w-full flex-col gap-2">
           <NuxtLink
@@ -45,6 +45,7 @@
 <script setup>
 import { ref } from "vue";
 import LoadingLandingPageCard from "@/components/layout/LoadingLandingPageCard.vue";
+import InlineError from "@/components/ui/InlineError.vue";
 import { useDomesticInstruments } from "@/composables/useDomesticInstruments";
 import { formatYear } from "@/utils/format";
 

--- a/frontend/components/landing-page/TempJurisdictionPicker.vue
+++ b/frontend/components/landing-page/TempJurisdictionPicker.vue
@@ -2,7 +2,11 @@
   <UCard class="cold-ucard overflow-visible">
     <div class="flex flex-col gap-6 md:flex-row md:items-center">
       <h2 class="card-title whitespace-nowrap">Open a Country Report</h2>
-      <div class="suggestions w-full">
+      <div v-if="isLoading" class="suggestions w-full">
+        <USkeleton class="h-10 w-full" />
+      </div>
+      <InlineError v-else-if="error" :error="error" />
+      <div v-else class="suggestions w-full">
         <JurisdictionSelectMenu
           :countries="jurisdictions || []"
           @country-selected="navigateToCountry"
@@ -15,11 +19,12 @@
 <script setup>
 import { useRouter } from "vue-router";
 import JurisdictionSelectMenu from "@/components/jurisdiction-comparison/JurisdictionSelectMenu.vue";
+import InlineError from "@/components/ui/InlineError.vue";
 import { useJurisdictions } from "@/composables/useJurisdictions";
 
 const router = useRouter();
 
-const { data: jurisdictions } = useJurisdictions();
+const { data: jurisdictions, isLoading, error } = useJurisdictions();
 
 const navigateToCountry = async (country) =>
   router.push(`/jurisdiction/${country.alpha3Code.toLowerCase()}`);

--- a/frontend/components/layouts/BaseDetailLayout.vue
+++ b/frontend/components/layouts/BaseDetailLayout.vue
@@ -1,6 +1,7 @@
 <template>
   <DetailDisplay
     :loading="props.loading"
+    :error="props.error ?? undefined"
     :result-data="props.data"
     :key-label-pairs="computedKeyLabelPairs"
     :value-class-map="{}"
@@ -32,6 +33,7 @@ const props = withDefaults(
   defineProps<{
     table: T;
     loading: boolean;
+    error?: Error | null;
     // Data accepts typed processed response or empty object for legacy/new pages
     data: TableProcessedMap[T] | Record<string, unknown>;
     // Label/tooltip maps - keys must match the table's processed type
@@ -49,6 +51,7 @@ const props = withDefaults(
     showSuggestEdit?: boolean;
   }>(),
   {
+    error: undefined,
     labels: () => ({}),
     tooltips: undefined,
     keyLabelPairs: undefined,

--- a/frontend/components/legal/CourtDecisionRenderer.vue
+++ b/frontend/components/legal/CourtDecisionRenderer.vue
@@ -14,6 +14,9 @@
         <template v-if="decisionsById.get(item as string)">
           {{ decisionsById.get(item as string)!.displayTitle }}
         </template>
+        <template v-else-if="decisionsError">
+          {{ item }}
+        </template>
         <template v-else>
           <LoadingBar />
         </template>
@@ -53,7 +56,8 @@ const decisionIds = computed(() => {
   return [...new Set(items.filter(Boolean))];
 });
 
-const { data: decisions } = useCourtDecisionsList(decisionIds);
+const { data: decisions, error: decisionsError } =
+  useCourtDecisionsList(decisionIds);
 
 const decisionsById = computed(() => {
   const map = new Map<string, CourtDecision>();

--- a/frontend/components/legal/InstrumentLink.vue
+++ b/frontend/components/legal/InstrumentLink.vue
@@ -2,7 +2,7 @@
   <span v-if="isLoading">
     <LoadingBar />
   </span>
-  <InlineError v-else-if="error" />
+  <InlineError v-else-if="error" :error="error" />
   <span v-else>
     <NuxtLink
       v-if="displayTitle && id"
@@ -19,6 +19,7 @@ import { ref, watch, computed } from "vue";
 import { useRecordDetails } from "@/composables/useRecordDetails";
 import { NuxtLink } from "#components";
 import LoadingBar from "@/components/layout/LoadingBar.vue";
+import InlineError from "@/components/ui/InlineError.vue";
 
 const props = defineProps({
   id: {

--- a/frontend/components/legal/LegalProvision.vue
+++ b/frontend/components/legal/LegalProvision.vue
@@ -2,7 +2,7 @@
   <div v-if="loading">
     <LoadingBar class="!mt-8" />
   </div>
-  <InlineError v-else-if="error" />
+  <InlineError v-else-if="error" :error="error" />
   <div v-else>
     <BaseLegalContent
       :title="displayTitle"
@@ -51,6 +51,7 @@ import { computed } from "vue";
 import { useLegalProvision } from "@/composables/useLegalProvision";
 import BaseLegalContent from "@/components/legal/BaseLegalContent.vue";
 import LoadingBar from "@/components/layout/LoadingBar.vue";
+import InlineError from "@/components/ui/InlineError.vue";
 
 const props = defineProps<{
   provisionId: string;

--- a/frontend/components/maps/BaseMap.vue
+++ b/frontend/components/maps/BaseMap.vue
@@ -80,12 +80,16 @@ const props = defineProps({
   },
 });
 
-const { data: geoJsonData } = useGeoJsonData();
-const { data: jurisdictions } = useJurisdictions();
+const { data: geoJsonData, error: geoJsonError } = useGeoJsonData();
+const { data: jurisdictions, error: jurisdictionsError } = useJurisdictions();
 
 const isDataReady = computed(
   () =>
-    geoJsonData.value && jurisdictions.value && jurisdictions.value.length > 0,
+    !geoJsonError.value &&
+    !jurisdictionsError.value &&
+    geoJsonData.value &&
+    jurisdictions.value &&
+    jurisdictions.value.length > 0,
 );
 
 // Create a map for quick lookup of answer coverages by ISO code

--- a/frontend/components/ui/BaseDetailDisplay.vue
+++ b/frontend/components/ui/BaseDetailDisplay.vue
@@ -22,7 +22,7 @@
     <LoadingCard />
   </template>
   <template v-else-if="error">
-    <InlineError />
+    <InlineError :error="error" />
   </template>
   <template v-else>
     <UCard
@@ -154,10 +154,15 @@ import BaseCardHeader from "@/components/ui/BaseCardHeader.vue";
 import NotificationBanner from "@/components/ui/NotificationBanner.vue";
 import LoadingCard from "@/components/layout/LoadingCard.vue";
 import DetailRow from "@/components/ui/DetailRow.vue";
+import InlineError from "@/components/ui/InlineError.vue";
 
 const props = defineProps({
   loading: Boolean,
-  error: Boolean,
+  error: {
+    type: [Object, Error],
+    required: false,
+    default: null,
+  },
   resultData: {
     type: Object,
     default: () => ({}),

--- a/frontend/components/ui/InlineError.vue
+++ b/frontend/components/ui/InlineError.vue
@@ -1,3 +1,21 @@
 <template>
-  <div class="text-sm text-gray-500">Failed to load</div>
+  <div class="text-sm text-gray-500">
+    {{ displayMessage }}
+  </div>
 </template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+
+const props = defineProps<{
+  error?: Error | { message?: string; statusMessage?: string } | null;
+}>();
+
+const displayMessage = computed(() => {
+  if (!props.error) return "Failed to load";
+  if (props.error instanceof Error) return props.error.message;
+  if (props.error.statusMessage) return props.error.statusMessage;
+  if (props.error.message) return props.error.message;
+  return "Failed to load";
+});
+</script>

--- a/frontend/components/ui/RelatedItemsList.vue
+++ b/frontend/components/ui/RelatedItemsList.vue
@@ -3,7 +3,7 @@
     <div v-if="isLoading">
       <LoadingBar />
     </div>
-    <InlineError v-else-if="error" />
+    <InlineError v-else-if="error" :error="error" />
     <div v-else-if="displayedItems.length" class="result-value-small">
       <div class="mb-2 flex flex-row flex-wrap gap-x-6 gap-y-2">
         <NuxtLink
@@ -40,20 +40,21 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
 import LoadingBar from "@/components/layout/LoadingBar.vue";
+import InlineError from "@/components/ui/InlineError.vue";
 import type { RelatedItem, EmptyValueBehavior } from "@/types/ui";
 
 const props = withDefaults(
   defineProps<{
     items?: RelatedItem[];
     isLoading?: boolean;
-    error?: boolean;
+    error?: Error;
     basePath: string;
     emptyValueBehavior?: EmptyValueBehavior;
   }>(),
   {
     items: () => [],
     isLoading: false,
-    error: false,
+    error: undefined,
     emptyValueBehavior: () => ({
       action: "display",
       fallback: "No items available",

--- a/frontend/pages/arbitral-award/[id].vue
+++ b/frontend/pages/arbitral-award/[id].vue
@@ -3,6 +3,7 @@
     <BaseDetailLayout
       table="Arbitral Awards"
       :loading="loading"
+      :error="error"
       :data="arbitralAward || {}"
       :labels="arbitralAwardLabels"
       :formatted-jurisdiction="arbitralAward?.formattedJurisdictions || []"
@@ -38,7 +39,9 @@ import { arbitralAwardLabels } from "@/config/labels";
 
 const route = useRoute();
 
-const { data: arbitralAward, isLoading: loading } = useArbitralAward(
-  computed(() => route.params.id as string),
-);
+const {
+  data: arbitralAward,
+  isLoading: loading,
+  error,
+} = useArbitralAward(computed(() => route.params.id as string));
 </script>

--- a/frontend/pages/arbitral-rule/[id].vue
+++ b/frontend/pages/arbitral-rule/[id].vue
@@ -3,6 +3,7 @@
     <BaseDetailLayout
       table="Arbitral Rules"
       :loading="loading"
+      :error="error"
       :data="arbitralRule || {}"
       :labels="arbitralRuleLabels"
       :show-suggest-edit="true"
@@ -31,7 +32,9 @@ import { arbitralRuleLabels } from "@/config/labels";
 
 const route = useRoute();
 
-const { data: arbitralRule, isLoading: loading } = useArbitralRule(
-  computed(() => route.params.id as string),
-);
+const {
+  data: arbitralRule,
+  isLoading: loading,
+  error,
+} = useArbitralRule(computed(() => route.params.id as string));
 </script>

--- a/frontend/pages/court-decision/[id].vue
+++ b/frontend/pages/court-decision/[id].vue
@@ -3,6 +3,7 @@
     <BaseDetailLayout
       table="Court Decisions"
       :loading="isLoading"
+      :error="error"
       :data="courtDecision || {}"
       :labels="courtDecisionLabels"
       :tooltips="courtDecisionTooltips"

--- a/frontend/pages/domestic-instrument/[id].vue
+++ b/frontend/pages/domestic-instrument/[id].vue
@@ -3,6 +3,7 @@
     <BaseDetailLayout
       table="Domestic Instruments"
       :loading="loading"
+      :error="error"
       :data="legalInstrument || {}"
       :labels="domesticInstrumentLabels"
       :tooltips="domesticInstrumentTooltips"
@@ -150,9 +151,11 @@ const route = useRoute();
 const textType = ref("Full Text of the Provision (English Translation)");
 const hasEnglishTranslation = ref(false);
 
-const { data: legalInstrument, isLoading: loading } = useDomesticInstrument(
-  computed(() => route.params.id as string),
-);
+const {
+  data: legalInstrument,
+  isLoading: loading,
+  error,
+} = useDomesticInstrument(computed(() => route.params.id as string));
 
 const isCompatible = (
   field:

--- a/frontend/pages/international-instrument/[id].vue
+++ b/frontend/pages/international-instrument/[id].vue
@@ -3,6 +3,7 @@
     <BaseDetailLayout
       table="International Instruments"
       :loading="loading"
+      :error="error"
       :data="internationalInstrument || {}"
       :labels="internationalInstrumentLabels"
       :tooltips="internationalInstrumentTooltips"
@@ -110,8 +111,11 @@ import { internationalInstrumentTooltips } from "@/config/tooltips";
 
 const route = useRoute();
 
-const { data: internationalInstrument, isLoading: loading } =
-  useInternationalInstrument(computed(() => route.params.id as string));
+const {
+  data: internationalInstrument,
+  isLoading: loading,
+  error,
+} = useInternationalInstrument(computed(() => route.params.id as string));
 
 const {
   data: provisions,

--- a/frontend/pages/jurisdiction/[id].vue
+++ b/frontend/pages/jurisdiction/[id].vue
@@ -3,6 +3,7 @@
     <BaseDetailLayout
       table="Jurisdictions"
       :loading="isLoading"
+      :error="error"
       :data="jurisdictionData || {}"
       :labels="jurisdictionLabels"
       :tooltips="jurisdictionTooltips"
@@ -133,9 +134,11 @@ import { jurisdictionTooltips } from "@/config/tooltips";
 
 const route = useRoute();
 
-const { isLoading, data: jurisdictionData } = useJurisdiction(
-  computed(() => route.params.id as string),
-);
+const {
+  isLoading,
+  data: jurisdictionData,
+  error,
+} = useJurisdiction(computed(() => route.params.id as string));
 
 const jurisdictionAlphaCode = computed(
   () => jurisdictionData.value?.alpha3Code as string,

--- a/frontend/pages/literature/[id].vue
+++ b/frontend/pages/literature/[id].vue
@@ -3,6 +3,7 @@
     <BaseDetailLayout
       table="Literature"
       :loading="loading"
+      :error="error"
       :data="literature || {}"
       :labels="literatureLabels"
       :tooltips="literatureTooltips"
@@ -104,7 +105,7 @@ const route = useRoute();
 
 const id = computed(() => route.params.id as string);
 
-const { data: literature, isLoading: loading } = useLiterature(id);
+const { data: literature, isLoading: loading, error } = useLiterature(id);
 
 // Source URL logic
 const sourceUrl = computed(() => {

--- a/frontend/pages/question/[id].vue
+++ b/frontend/pages/question/[id].vue
@@ -3,6 +3,7 @@
     <BaseDetailLayout
       table="Questions"
       :loading="isLoading"
+      :error="error"
       :data="answerData || {}"
       :labels="questionLabels"
       :tooltips="questionTooltips"
@@ -96,9 +97,11 @@ import { questionTooltips } from "@/config/tooltips";
 
 const route = useRoute();
 
-const { data: answerData, isLoading } = useAnswer(
-  computed(() => route.params.id as string),
-);
+const {
+  data: answerData,
+  isLoading,
+  error,
+} = useAnswer(computed(() => route.params.id as string));
 
 const questionSuffix = computed(() => {
   // Extract question suffix from the answer ID (route param)

--- a/frontend/pages/regional-instrument/[id].vue
+++ b/frontend/pages/regional-instrument/[id].vue
@@ -3,6 +3,7 @@
     <BaseDetailLayout
       table="Regional Instruments"
       :loading="loading"
+      :error="error"
       :data="regionalInstrument || {}"
       :labels="regionalInstrumentLabels"
       :tooltips="regionalInstrumentTooltips"
@@ -94,7 +95,9 @@ import { regionalInstrumentTooltips } from "@/config/tooltips";
 
 const route = useRoute();
 
-const { data: regionalInstrument, isLoading: loading } = useRegionalInstrument(
-  computed(() => route.params.id as string),
-);
+const {
+  data: regionalInstrument,
+  isLoading: loading,
+  error,
+} = useRegionalInstrument(computed(() => route.params.id as string));
 </script>


### PR DESCRIPTION
Create reusable InlineError component and add error state handling to components that were missing it, preventing JavaScript crashes when API calls fail. Consistently use `error` (not `isError`) for more context.

Components fixed:
- Landing page: RecentDomesticInstruments, SuccessfulLegalTransplantations, PlotCourtDecisionsJurisdiction, LeadingCases
- Legal: InstrumentLink, LegalProvision
- UI: BaseDetailDisplay (new error prop), RelatedItemsList (new error prop)
- Content: JurisdictionQuestions