### PR TITLE
Fix USelectMenu styling and responsive width issues

### DIFF
--- a/frontend/app/assets/styles.css
+++ b/frontend/app/assets/styles.css
@@ -825,6 +825,12 @@ ul[role="listbox"] li[aria-selected="true"] .iconify {
 ul[role="listbox"] input {
   padding: 0.75rem !important;
   border-color: rgb(229 231 235) !important;
+  background-color: white !important;
+}
+
+/* USelectMenu content wrapper - ensure white background */
+.cold-uselectmenu [data-slot="content"] {
+  background-color: white !important;
 }
 
 /* Popper Hover & Active States */

--- a/frontend/app/assets/styles.css
+++ b/frontend/app/assets/styles.css
@@ -909,6 +909,12 @@ ul[role="listbox"] li[data-headlessui-state="selected"]:hover {
 
 /* Form Inputs ----------------------------------------------- */
 
+/* Ensure all form textareas and inputs take full width by default */
+textarea,
+[data-slot="control"] textarea {
+  width: 100% !important;
+}
+
 /* Base input style: apply to inputs by adding the `cold-input` class. */
 .cold-input,
 input.cold-input,

--- a/frontend/app/components/case-analyzer/AnalysisReviewForm.vue
+++ b/frontend/app/components/case-analyzer/AnalysisReviewForm.vue
@@ -62,7 +62,7 @@
           v-model="localForm.choiceOfLawSections"
           :disabled="isFieldDisabled('choiceOfLawSections')"
           :rows="6"
-          class="print:hidden"
+          class="w-full print:hidden"
         />
         <div class="print-field-value">
           {{ localForm.choiceOfLawSections }}
@@ -81,7 +81,7 @@
           v-model="localForm.themes"
           :disabled="isFieldDisabled('themes')"
           :rows="1"
-          class="print:hidden"
+          class="w-full print:hidden"
         />
         <div class="print-field-value">
           {{ localForm.themes }}
@@ -100,7 +100,7 @@
           v-model="localForm.caseCitation"
           :disabled="isFieldDisabled('caseCitation')"
           :rows="2"
-          class="print:hidden"
+          class="w-full print:hidden"
         />
         <div class="print-field-value">
           {{ localForm.caseCitation }}
@@ -119,7 +119,7 @@
           v-model="localForm.caseRelevantFacts"
           :disabled="isFieldDisabled('caseRelevantFacts')"
           :rows="6"
-          class="print:hidden"
+          class="w-full print:hidden"
         />
         <div class="print-field-value">
           {{ localForm.caseRelevantFacts }}
@@ -138,7 +138,7 @@
           v-model="localForm.casePILProvisions"
           :disabled="isFieldDisabled('casePILProvisions')"
           :rows="2"
-          class="print:hidden"
+          class="w-full print:hidden"
         />
         <div class="print-field-value">
           {{ localForm.casePILProvisions }}
@@ -157,7 +157,7 @@
           v-model="localForm.caseChoiceofLawIssue"
           :disabled="isFieldDisabled('caseChoiceofLawIssue')"
           :rows="6"
-          class="print:hidden"
+          class="w-full print:hidden"
         />
         <div class="print-field-value">
           {{ localForm.caseChoiceofLawIssue }}
@@ -176,7 +176,7 @@
           v-model="localForm.caseCourtsPosition"
           :disabled="isFieldDisabled('caseCourtsPosition')"
           :rows="6"
-          class="print:hidden"
+          class="w-full print:hidden"
         />
         <div class="print-field-value">
           {{ localForm.caseCourtsPosition }}
@@ -195,7 +195,7 @@
           v-model="localForm.caseObiterDicta"
           :disabled="isFieldDisabled('caseObiterDicta')"
           :rows="3"
-          class="print:hidden"
+          class="w-full print:hidden"
         />
         <div class="print-field-value">
           {{ localForm.caseObiterDicta }}
@@ -214,7 +214,7 @@
           v-model="localForm.caseDissentingOpinions"
           :disabled="isFieldDisabled('caseDissentingOpinions')"
           :rows="3"
-          class="print:hidden"
+          class="w-full print:hidden"
         />
         <div class="print-field-value">
           {{ localForm.caseDissentingOpinions }}
@@ -233,7 +233,7 @@
           v-model="localForm.caseAbstract"
           :disabled="isFieldDisabled('caseAbstract')"
           :rows="6"
-          class="print:hidden"
+          class="w-full print:hidden"
         />
         <div class="print-field-value">
           {{ localForm.caseAbstract }}

--- a/frontend/app/components/case-analyzer/JurisdictionConfirmCard.vue
+++ b/frontend/app/components/case-analyzer/JurisdictionConfirmCard.vue
@@ -18,6 +18,7 @@
           :items="legalSystemOptions"
           placeholder="Select legal system"
           size="xl"
+          class="cold-uselectmenu w-full"
           :disabled="isLoading"
           @update:model-value="
             (value) => handleLegalSystemUpdate(value as string)

--- a/frontend/app/components/jurisdiction-comparison/JurisdictionSelectMenu.vue
+++ b/frontend/app/components/jurisdiction-comparison/JurisdictionSelectMenu.vue
@@ -2,7 +2,7 @@
   <USelectMenu
     v-model="internalSelected"
     :search-input="{ placeholder: 'Search a Jurisdiction...' }"
-    class="cold-uselectmenu z-200 w-72 lg:w-96"
+    class="cold-uselectmenu z-200 w-full"
     :placeholder="placeholder"
     :items="selectItems"
     :disabled="disabled"


### PR DESCRIPTION
## Summary
This PR fixes styling inconsistencies in USelectMenu components by ensuring proper background colors and improving responsive width handling across the application.

## Key Changes
- **CSS Updates**: Added explicit white background color to USelectMenu input fields and content wrapper to prevent styling inheritance issues
- **JurisdictionConfirmCard**: Added `cold-uselectmenu` class and `w-full` utility to ensure consistent styling and full-width responsiveness
- **JurisdictionSelectMenu**: Changed fixed width classes (`w-72 lg:w-96`) to `w-full` for better responsive behavior across all screen sizes

## Implementation Details
- The new CSS rule for `.cold-uselectmenu [data-slot="content"]` targets the content wrapper specifically to ensure the white background is applied consistently
- Using `!important` flags maintains specificity and prevents style conflicts with other CSS rules
- The `w-full` width approach provides better flexibility and ensures components adapt properly to their container sizes rather than using fixed breakpoint-based widths

https://claude.ai/code/session_01CHaPXk8sUSdsZy17RdXzH7