### PR TITLE
Replace custom CSS with UButton trailing icons for link components

### DIFF
--- a/frontend/app/app.config.ts
+++ b/frontend/app/app.config.ts
@@ -53,6 +53,15 @@ export default defineAppConfig({
           },
         },
         {
+          color: "neutral" as const,
+          variant: "ghost" as const,
+          class: {
+            base: "group cursor-pointer gap-0",
+            trailingIcon:
+              "h-3 w-0 ml-0 shrink-0 opacity-0 transition-[width,margin,opacity] duration-200 group-hover:w-3 group-hover:ml-1 group-hover:opacity-100",
+          },
+        },
+        {
           color: "primary" as const,
           variant: "link" as const,
           class: "font-medium",

--- a/frontend/app/assets/styles.css
+++ b/frontend/app/assets/styles.css
@@ -2047,36 +2047,6 @@ button.cold-toggle-btn[aria-pressed="true"] {
   color: var(--color-cold-purple);
 }
 
-.link-chip--neutral::after {
-  content: "";
-  display: inline-block;
-  width: 0;
-  height: 12px;
-  margin-left: 0;
-  background-color: currentColor;
-  mask-image: var(--icon-arrow-right);
-  mask-size: contain;
-  mask-repeat: no-repeat;
-  mask-position: center;
-  -webkit-mask-image: var(--icon-arrow-right);
-  -webkit-mask-size: contain;
-  -webkit-mask-repeat: no-repeat;
-  -webkit-mask-position: center;
-  -webkit-mask-size: contain;
-  -webkit-mask-repeat: no-repeat;
-  -webkit-mask-position: center;
-  opacity: 0;
-  transition:
-    width 0.2s ease,
-    margin-left 0.2s ease,
-    opacity 0.15s ease;
-}
-
-.link-chip--neutral:hover::after {
-  width: 1rem;
-  opacity: 1;
-}
-
 .link-chip--neutral:focus-visible {
   outline: 2px solid var(--color-cold-purple);
   outline-offset: 2px;

--- a/frontend/app/components/layout/NavMenu.vue
+++ b/frontend/app/components/layout/NavMenu.vue
@@ -135,27 +135,30 @@ onUnmounted(() => {
 defineExpose({ showMenu });
 </script>
 
-<style scoped>
-:deep(.custom-nav-links) {
+<style>
+/* Unscoped so styles reliably apply through ULink component boundary */
+.custom-nav-links {
   color: var(--color-cold-night) !important;
   text-decoration: none !important;
   font-weight: 600 !important;
 }
 
-:deep(.custom-nav-links.active) {
+.custom-nav-links.active {
   text-decoration: underline !important;
   text-underline-offset: 6px !important;
   text-decoration-thickness: 2px !important;
   text-decoration-color: var(--color-cold-purple) !important;
 }
 
-:deep(.custom-nav-links:hover) {
+.custom-nav-links:hover {
   text-decoration: underline !important;
   text-underline-offset: 6px !important;
   text-decoration-thickness: 2px !important;
   text-decoration-color: var(--color-cold-purple) !important;
 }
+</style>
 
+<style scoped>
 @media (max-width: 639px) {
   .mobile-nav-group {
     gap: 0.75rem;

--- a/frontend/app/components/legal/CourtDecisionRenderer.vue
+++ b/frontend/app/components/legal/CourtDecisionRenderer.vue
@@ -12,6 +12,7 @@
           variant="ghost"
           color="neutral"
           class="link-chip--neutral"
+          trailing-icon="i-material-symbols:arrow-forward"
           :to="`/court-decision/${item}`"
         >
           <template v-if="decisionsById.get(item)">
@@ -30,6 +31,7 @@
           variant="ghost"
           color="neutral"
           class="link-chip--neutral"
+          trailing-icon="i-material-symbols:arrow-forward"
           :to="`/court-decision/${normalizedItems[0]!}`"
         >
           <template v-if="decisionsById.get(normalizedItems[0]!)">

--- a/frontend/app/components/sources/SourceExternalLink.vue
+++ b/frontend/app/components/sources/SourceExternalLink.vue
@@ -8,7 +8,9 @@
       color="secondary"
       size="sm"
       :icon="openAccess ? undefined : 'i-material-symbols:open-in-new'"
-      :trailing-icon="openAccess ? undefined : 'i-material-symbols:open-in-new'"
+      :trailing-icon="
+        openAccess ? undefined : 'i-material-symbols:arrow-forward'
+      "
       @click.stop
     >
       <template v-if="openAccess" #leading>

--- a/frontend/app/components/ui/CardTags.vue
+++ b/frontend/app/components/ui/CardTags.vue
@@ -100,14 +100,23 @@
       </template>
     </template>
 
-    <NuxtLink
+    <UButton
       v-for="(theme, index) in formattedTheme"
       :key="`theme-${index}`"
-      class="label-theme label-link cursor-pointer"
       :to="'/search?theme=' + encodeURIComponent(theme).replace(/%20/g, '+')"
+      variant="link"
+      color="neutral"
+      trailing-icon="i-material-symbols:arrow-forward"
+      class="label-theme group"
+      :ui="{
+        base: 'gap-0 transition-[margin-right] duration-200 hover:mr-[-1rem]',
+        trailingIcon:
+          'h-3 w-0 ml-0 shrink-0 opacity-0 transition-[width,margin,opacity] duration-200 group-hover:w-3 group-hover:ml-1 group-hover:opacity-100',
+      }"
+      @click.stop
     >
       {{ theme }}
-    </NuxtLink>
+    </UButton>
   </div>
 </template>
 

--- a/frontend/app/components/ui/PdfLink.vue
+++ b/frontend/app/components/ui/PdfLink.vue
@@ -7,7 +7,7 @@
       color="secondary"
       size="sm"
       icon="i-material-symbols:picture-as-pdf-outline"
-      trailing-icon="i-material-symbols:picture-as-pdf-outline"
+      trailing-icon="i-material-symbols:arrow-forward"
       aria-label="Download PDF for record"
       @click.stop
     >

--- a/frontend/app/components/ui/RelatedItemsList.vue
+++ b/frontend/app/components/ui/RelatedItemsList.vue
@@ -6,14 +6,17 @@
     <InlineError v-else-if="error" :error="error" />
     <div v-else-if="displayedItems.length" class="result-value-small">
       <div class="mb-2 flex flex-row flex-wrap gap-x-6 gap-y-2">
-        <NuxtLink
+        <UButton
           v-for="item in displayedItems"
           :key="item.id"
+          variant="ghost"
+          color="neutral"
           class="link-chip--neutral"
+          trailing-icon="i-material-symbols:arrow-forward"
           :to="item.id.startsWith('/') ? item.id : `${basePath}/${item.id}`"
         >
           {{ item.title }}
-        </NuxtLink>
+        </UButton>
       </div>
       <ShowMoreLess
         v-if="items.length > 10"

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -32,8 +32,16 @@
                 <UButton
                   to="/search"
                   size="lg"
-                  class="hero-cta"
+                  class="hero-cta group"
                   icon="i-material-symbols:search"
+                  trailing-icon="i-material-symbols:arrow-forward"
+                  :ui="{
+                    base: 'gap-0',
+                    leadingIcon:
+                      'h-5 w-5 mr-2 opacity-100 transition-[width,margin,opacity] duration-200 group-hover:w-0 group-hover:mr-0 group-hover:opacity-0',
+                    trailingIcon:
+                      'h-5 w-0 ml-0 opacity-0 transition-[width,margin,opacity] duration-200 group-hover:w-5 group-hover:ml-2 group-hover:opacity-100',
+                  }"
                 >
                   Start Exploring
                 </UButton>
@@ -41,8 +49,16 @@
                   to="/court-decision/new"
                   size="lg"
                   variant="outline"
-                  class="hero-cta-secondary"
+                  class="hero-cta-secondary group"
                   icon="i-material-symbols:category-search-outline"
+                  trailing-icon="i-material-symbols:arrow-forward"
+                  :ui="{
+                    base: 'gap-0',
+                    leadingIcon:
+                      'h-5 w-5 mr-2 opacity-100 transition-[width,margin,opacity] duration-200 group-hover:w-0 group-hover:mr-0 group-hover:opacity-0',
+                    trailingIcon:
+                      'h-5 w-0 ml-0 opacity-0 transition-[width,margin,opacity] duration-200 group-hover:w-5 group-hover:ml-2 group-hover:opacity-100',
+                  }"
                 >
                   Analyze Case
                 </UButton>


### PR DESCRIPTION
## Summary
Refactored link components throughout the application to use UButton's built-in `trailing-icon` prop instead of custom CSS pseudo-elements. This improves maintainability and consistency by leveraging the UI component library's animation capabilities.

## Key Changes
- **App Config**: Added new `neutral` + `ghost` button variant configuration with animated trailing icon styles
- **Removed Custom CSS**: Deleted `.link-chip--neutral::after` pseudo-element styles from `styles.css` that manually created arrow animations
- **Updated Components**:
  - `CourtDecisionRenderer.vue`: Converted UButton links to use `trailing-icon` prop
  - `SourceExternalLink.vue`: Changed trailing icon from `open-in-new` to `arrow-forward`
  - `CardTags.vue`: Migrated from `NuxtLink` to `UButton` with trailing icon and custom animation config
  - `PdfLink.vue`: Updated trailing icon to `arrow-forward`
  - `RelatedItemsList.vue`: Converted from `NuxtLink` to `UButton` with trailing icon
  - `pages/index.vue`: Enhanced hero CTA buttons with animated leading/trailing icons that swap on hover
- **Style Refactoring**: Removed scoped style boundary in `NavMenu.vue` to ensure styles reliably apply through component boundaries

## Implementation Details
- Trailing icons use consistent animation: width/margin/opacity transitions over 200ms
- Hero buttons feature icon swap behavior: leading icon fades out while trailing icon fades in on hover
- All icon animations maintain visual consistency with the new `neutral` button variant configuration

https://claude.ai/code/session_01DdgpbTLkXroJMvXg4Ad1v1