### PR TITLE
fix(claude): correct hooks schema in settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,17 +3,32 @@
     "PostToolUse": [
       {
         "matcher": "Edit|Write",
-        "command": "filepath=$(echo \"$TOOL_INPUT\" | grep -o '\"file_path\":\\s*\"[^\"]*\"' | head -1 | sed 's/.*\"file_path\":\\s*\"//;s/\"$//'); case \"$filepath\" in */frontend/*) cd frontend && npx prettier --write \"$filepath\" 2>/dev/null;; */backend/*.py) cd backend && uv run ruff format \"$filepath\" 2>/dev/null && uv run ruff check --fix \"$filepath\" 2>/dev/null;; esac; exit 0"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "filepath=$(echo \"$TOOL_INPUT\" | grep -o '\"file_path\":\\s*\"[^\"]*\"' | head -1 | sed 's/.*\"file_path\":\\s*\"//;s/\"$//'); case \"$filepath\" in */frontend/*) cd frontend && npx prettier --write \"$filepath\" 2>/dev/null;; */backend/*.py) cd backend && uv run ruff format \"$filepath\" 2>/dev/null && uv run ruff check --fix \"$filepath\" 2>/dev/null;; esac; exit 0"
+          }
+        ]
       }
     ],
     "PreToolUse": [
       {
         "matcher": "Edit|Write",
-        "command": "echo \"$TOOL_INPUT\" | grep -q '\"file_path\".*\\.env\"' && echo 'BLOCKED: do not edit .env files — use .blueprint.env for templates' && exit 1; exit 0"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo \"$TOOL_INPUT\" | grep -q '\"file_path\".*\\.env\"' && echo 'BLOCKED: do not edit .env files — use .blueprint.env for templates' && exit 1; exit 0"
+          }
+        ]
       },
       {
         "matcher": "Bash",
-        "command": "echo \"$TOOL_INPUT\" | grep -qiE '(alembic\\s+(upgrade|downgrade|stamp)|psql|pg_dump|pg_restore|dropdb|createdb|DROP\\s|DELETE\\s+FROM|TRUNCATE|ALTER\\s+TABLE|INSERT\\s+INTO|UPDATE\\s+.*SET)' && echo 'BLOCKED: direct database operations are not allowed — only prod DB exists' && exit 1; exit 0"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo \"$TOOL_INPUT\" | grep -qiE '(alembic\\s+(upgrade|downgrade|stamp)|psql|pg_dump|pg_restore|dropdb|createdb|DROP\\s|DELETE\\s+FROM|TRUNCATE|ALTER\\s+TABLE|INSERT\\s+INTO|UPDATE\\s+.*SET)' && echo 'BLOCKED: direct database operations are not allowed — only prod DB exists' && exit 1; exit 0"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary

- Fixes the hooks schema in `.claude/settings.json` so all three hooks (auto-format on Edit/Write, .env file protection, DB operation blocking) actually load and run
- Each hook entry had `command` as a direct property instead of wrapping it in the required `hooks: [{type: "command", command: "..."}]` array structure

## Test plan

- [ ] Restart Claude Code and confirm no settings validation errors appear
- [ ] Edit a frontend file and verify Prettier auto-formats on save
- [ ] Attempt to edit a `.env` file and confirm it's blocked
- [ ] Attempt a DB operation via Bash and confirm it's blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)