### PR TITLE
fix(international-instrument): sort HCCH answers by question number

### DIFF
--- a/frontend/app/pages/international-instrument/[coldId].vue
+++ b/frontend/app/pages/international-instrument/[coldId].vue
@@ -54,8 +54,12 @@ const { data, isLoading, error } = useEntityData(
 );
 
 const hcchAnswers = computed(() =>
-  (data.value?.relations.hcchAnswers ?? []).filter(
-    (a) => a.adaptedQuestion || a.position,
-  ),
+  (data.value?.relations.hcchAnswers ?? [])
+    .filter((a) => a.adaptedQuestion || a.position)
+    .sort((a, b) =>
+      (a.coldId ?? "").localeCompare(b.coldId ?? "", undefined, {
+        numeric: true,
+      }),
+    ),
 );
 </script>


### PR DESCRIPTION
## Summary
- Sort the HCCH Questions & Answers list on the International Instrument page by question number (NocoDB standard order) instead of DB insertion order, using `localeCompare` with `{ numeric: true }` on `coldId` (format `HCCH-<question_number>-<primary_theme>`).
- Frontend-only fix since project rules forbid editing migrations; the ideal `ORDER BY` in `data_views.get_entity_detail` is left to a future migration.

Closes #465

## Test plan
- [ ] Visit `/international-instrument/II-Pri-1` and confirm questions render 1, 2, …, 10 in order.