### PR TITLE
fix(connect-card): center subtitle when title is centered

### DIFF
--- a/frontend/app/components/landing-page/ConnectCard.vue
+++ b/frontend/app/components/landing-page/ConnectCard.vue
@@ -6,7 +6,11 @@
         <h2 class="card-title" :class="{ 'text-center': centerTitle }">
           {{ title }}
         </h2>
-        <p v-if="subtitle" class="card-subtitle">
+        <p
+          v-if="subtitle"
+          class="card-subtitle"
+          :class="{ 'text-center': centerTitle }"
+        >
           {{ subtitle }}
         </p>
       </div>


### PR DESCRIPTION
## Summary
- On the Data Input (`/submit`) page, `ConnectCard` titles were centered but subtitles were left-aligned, creating a visual mismatch (issue #469).
- The subtitle now inherits `text-center` from the same `centerTitle` prop that controls the title, keeping the HCCH landing-page card (which opts out via `:center-title="false"`) left-aligned.

Closes #469

## Test plan
- [x] `pnpm run check` (prettier, eslint, vue-tsc, vitest) — all green
- [ ] Visual check of `/submit` cards in browser