### PR TITLE
feat(court-decision): leading cases page + jurisdiction pill fixes

### DIFF
--- a/backend/app/services/search.py
+++ b/backend/app/services/search.py
@@ -44,6 +44,26 @@ class SearchService:
         "questions": "data_views.base_questions",
     }
 
+    _TABLE_TO_FTS_ENRICHMENT: dict[str, tuple[str, dict[str, str]]] = {
+        "answers": (
+            "data_views.answers",
+            {"question": "Questions", "jurisdictions": "Jurisdictions", "themes": "Themes"},
+        ),
+        "hcch answers": ("data_views.hcch_answers", {"themes": "Themes"}),
+        "court decisions": (
+            "data_views.court_decisions",
+            {"jurisdictions": "Jurisdictions", "themes": "Themes"},
+        ),
+        "domestic instruments": (
+            "data_views.domestic_instruments",
+            {"jurisdictions": "Jurisdictions"},
+        ),
+        "literature": (
+            "data_views.literature",
+            {"themes": "Themes"},
+        ),
+    }
+
     def _complete_view_for_table(self, table: str) -> str:
         if not table:
             raise ValueError("No table provided")
@@ -51,6 +71,34 @@ class SearchService:
         if not view or not _SAFE_IDENTIFIER.match(view):
             raise ValueError(f"Unsupported table for full/filtered query: {table}")
         return view
+
+    def _fts_enrichment_for_table(self, table: str) -> tuple[str, dict[str, str]] | None:
+        enrichment = self._TABLE_TO_FTS_ENRICHMENT.get(table.strip().lower())
+        if not enrichment:
+            return None
+        view, fields = enrichment
+        if not _SAFE_IDENTIFIER.match(view):
+            return None
+        if any(not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", k) for k in fields):
+            return None
+        if any(not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", v) for v in fields.values()):
+            return None
+        return view, fields
+
+    def _build_select_sql(self, table: str, alias: str = "c", where_sql: str = "") -> str:
+        view = self._complete_view_for_table(table)
+        enrichment = self._fts_enrichment_for_table(table)
+        if enrichment is None:
+            return f"SELECT {alias}.id AS record_id, to_jsonb({alias}.*) AS complete_record FROM {view} {alias}{where_sql}"
+        fts_view, fields = enrichment
+        pairs = ", ".join(f"'{key}', sv.\"{col}\"" for key, col in fields.items())
+        return (
+            f"SELECT {alias}.id AS record_id, "
+            f"to_jsonb({alias}.*) || jsonb_build_object({pairs}) AS complete_record "
+            f"FROM {view} {alias} "
+            f"LEFT JOIN {fts_view} sv ON sv.id = {alias}.id"
+            f"{where_sql}"
+        )
 
     VALID_DETAIL_TABLES: set[str] = {
         "Answers",
@@ -125,8 +173,7 @@ class SearchService:
 
     def full_table(self, table: str, response_type: str = "parsed") -> list[dict[str, Any]]:
         try:
-            view = self._complete_view_for_table(table)
-            sql = f"SELECT c.id AS record_id, to_jsonb(c.*) AS complete_record FROM {view} c"
+            sql = self._build_select_sql(table)
             rows = self.db.execute_query(sql, {}) or []
             return self._flatten_rows(rows, table, response_type)
         except Exception as e:
@@ -135,10 +182,9 @@ class SearchService:
 
     def filtered_table(self, table: str, filters: list[Any], response_type: str = "parsed") -> list[dict[str, Any]]:
         try:
-            view = self._complete_view_for_table(table)
             alias = "c"
             where_sql, params = build_filter_clause(alias, filters)
-            sql = f"SELECT {alias}.id AS record_id, to_jsonb({alias}.*) AS complete_record FROM {view} {alias}{where_sql}"
+            sql = self._build_select_sql(table, alias=alias, where_sql=where_sql)
             rows = self.db.execute_query(sql, params) or []
             return self._flatten_rows(rows, table, response_type)
         except Exception as e:

--- a/frontend/app/components/entity/EntityDrawer.vue
+++ b/frontend/app/components/entity/EntityDrawer.vue
@@ -112,6 +112,7 @@ import JurisdictionDrawerQA from "@/components/jurisdiction/JurisdictionDrawerQA
 import DrawerAnswerMap from "@/components/jurisdiction/DrawerAnswerMap.vue";
 import CardTags from "@/components/ui/CardTags.vue";
 import { getLabelColorClassByVariant } from "@/config/entityRegistry";
+import { primaryJurisdictionAlpha3 } from "@/utils/jurisdictionParser";
 
 const contentComponents: Record<string, Component> = {
   CourtDecisionContent,
@@ -168,12 +169,19 @@ const headerJurisdictions = computed<string[]>(() => {
   if (!("relations" in data)) return [];
   const jurisdictions = data.relations.jurisdictions;
   if (!jurisdictions?.length) return [];
-  const filtered = jurisdictions
-    .filter((j) => j.coldId !== pageJurisdictionCode.value)
-    .map((j) => j.name || "")
-    .filter((name) => name);
-  if (filtered.length !== 1) return [];
-  return filtered;
+  const filtered = jurisdictions.filter(
+    (j) => j.coldId !== pageJurisdictionCode.value,
+  );
+  if (filtered.length === 1) {
+    const name = filtered[0]?.name;
+    return name ? [name] : [];
+  }
+  const primary = primaryJurisdictionAlpha3(
+    data as Record<string, unknown>,
+  ).toUpperCase();
+  if (!primary) return [];
+  const match = filtered.find((j) => j.coldId?.toUpperCase() === primary);
+  return match?.name ? [match.name] : [];
 });
 
 const headerSourceTable = computed(() => config.value?.singularLabel ?? "");

--- a/frontend/app/components/landing-page/LeadingCases.vue
+++ b/frontend/app/components/landing-page/LeadingCases.vue
@@ -6,7 +6,7 @@
     :error="error"
   >
     <FlagTitleYearItem
-      v-for="decision in leadingCases?.slice(0, 3)"
+      v-for="decision in leadingCases"
       :key="String(decision.id || '')"
       :to="`/court-decision/${decision.id}`"
       :iso3="decision.jurisdictionsAlpha3Code || ''"

--- a/frontend/app/components/landing-page/LeadingCases.vue
+++ b/frontend/app/components/landing-page/LeadingCases.vue
@@ -4,9 +4,11 @@
     subtitle="Read top-ranked court decisions"
     :loading="isLoading"
     :error="error"
+    header-link="/court-decision/leading-cases"
+    header-class="cursor-pointer text-left md:whitespace-nowrap"
   >
     <FlagTitleYearItem
-      v-for="decision in leadingCases"
+      v-for="decision in leadingCases?.slice(0, 6)"
       :key="String(decision.id || '')"
       :to="`/court-decision/${decision.id}`"
       :iso3="decision.jurisdictionsAlpha3Code || ''"

--- a/frontend/app/components/ui/CardHeader.vue
+++ b/frontend/app/components/ui/CardHeader.vue
@@ -44,6 +44,7 @@
 import { computed } from "vue";
 import { parseJurisdictionString } from "@/utils/jurisdictionParser";
 import { getSingularLabel, getLabelColorClass } from "@/config/entityRegistry";
+import { useJurisdictionLookup } from "@/composables/useJurisdictions";
 import CardTags from "@/components/ui/CardTags.vue";
 import CardActions from "@/components/ui/CardActions.vue";
 
@@ -72,6 +73,19 @@ const props = withDefaults(
   },
 );
 
+const { findJurisdictionByCode } = useJurisdictionLookup();
+
+const COLD_ID_ALPHA3_PATTERN = /^[A-Z]+-([A-Z]{3})-/;
+
+const primaryJurisdictionCode = computed(() => {
+  const explicit = String(props.resultData.jurisdictionsAlpha3Code || "");
+  if (explicit) return explicit.toUpperCase();
+  const fromColdId = String(
+    props.resultData.coldId || props.resultData.id || "",
+  ).match(COLD_ID_ALPHA3_PATTERN);
+  return fromColdId?.[1] ?? "";
+});
+
 const resolvedJurisdiction = computed(() => {
   if (props.formattedJurisdiction.length > 0) {
     return props.formattedJurisdiction;
@@ -91,8 +105,14 @@ const resolvedJurisdiction = computed(() => {
   }
 
   const parsed = parseJurisdictionString(jurisdictionString);
-  if (parsed.length > 1) return [];
-  return parsed;
+  if (parsed.length <= 1) return parsed;
+
+  const primary = findJurisdictionByCode(primaryJurisdictionCode.value);
+  if (!primary?.name) return [];
+  const match = parsed.find(
+    (name) => name.toLowerCase() === primary.name.toLowerCase(),
+  );
+  return match ? [match] : [];
 });
 
 const formattedSourceTable = computed(() => {

--- a/frontend/app/components/ui/CardHeader.vue
+++ b/frontend/app/components/ui/CardHeader.vue
@@ -42,7 +42,10 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import { parseJurisdictionString } from "@/utils/jurisdictionParser";
+import {
+  parseJurisdictionString,
+  primaryJurisdictionAlpha3,
+} from "@/utils/jurisdictionParser";
 import { getSingularLabel, getLabelColorClass } from "@/config/entityRegistry";
 import { useJurisdictionLookup } from "@/composables/useJurisdictions";
 import CardTags from "@/components/ui/CardTags.vue";
@@ -75,16 +78,9 @@ const props = withDefaults(
 
 const { findJurisdictionByCode } = useJurisdictionLookup();
 
-const COLD_ID_ALPHA3_PATTERN = /^[A-Z]+-([A-Z]{3})-/;
-
-const primaryJurisdictionCode = computed(() => {
-  const explicit = String(props.resultData.jurisdictionsAlpha3Code || "");
-  if (explicit) return explicit.toUpperCase();
-  const fromColdId = String(
-    props.resultData.coldId || props.resultData.id || "",
-  ).match(COLD_ID_ALPHA3_PATTERN);
-  return fromColdId?.[1] ?? "";
-});
+const primaryJurisdictionCode = computed(() =>
+  primaryJurisdictionAlpha3(props.resultData),
+);
 
 const resolvedJurisdiction = computed(() => {
   if (props.formattedJurisdiction.length > 0) {

--- a/frontend/app/components/ui/CardHeader.vue
+++ b/frontend/app/components/ui/CardHeader.vue
@@ -100,19 +100,20 @@ const resolvedJurisdiction = computed(() => {
       "",
   );
 
-  if (!jurisdictionString) {
-    return [];
-  }
-
-  const parsed = parseJurisdictionString(jurisdictionString);
-  if (parsed.length <= 1) return parsed;
+  const parsed = jurisdictionString
+    ? parseJurisdictionString(jurisdictionString)
+    : [];
+  if (parsed.length === 1) return parsed;
 
   const primary = findJurisdictionByCode(primaryJurisdictionCode.value);
-  if (!primary?.name) return [];
-  const match = parsed.find(
-    (name) => name.toLowerCase() === primary.name.toLowerCase(),
-  );
-  return match ? [match] : [];
+  if (primary?.name) {
+    if (parsed.length === 0) return [primary.name];
+    const match = parsed.find(
+      (name) => name.toLowerCase() === primary.name.toLowerCase(),
+    );
+    if (match) return [match];
+  }
+  return [];
 });
 
 const formattedSourceTable = computed(() => {

--- a/frontend/app/pages/court-decision/leading-cases.vue
+++ b/frontend/app/pages/court-decision/leading-cases.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="py-6">
+    <h1 class="card-title mb-1">Leading Cases</h1>
+    <p class="card-subtitle mb-8">Top-ranked court decisions</p>
+
+    <div v-if="isLoading" class="results-grid">
+      <LoadingCard v-for="n in 6" :key="`loading-${n}`" />
+    </div>
+
+    <InlineError v-else-if="error" :error="error" />
+
+    <div v-else-if="!leadingCases?.length" class="py-12 text-center">
+      <p class="result-value-small">No leading cases found.</p>
+    </div>
+
+    <div v-else class="results-grid">
+      <div
+        v-for="decision in leadingCases"
+        :key="String(decision.id || '')"
+        class="result-item"
+      >
+        <SearchResultCardContent
+          :result-data="decision as unknown as AnySearchResult"
+          card-type="Court Decisions"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import SearchResultCardContent from "@/components/search-results/SearchResultCardContent.vue";
+import LoadingCard from "@/components/layout/LoadingCard.vue";
+import InlineError from "@/components/ui/InlineError.vue";
+import { useLeadingCases } from "@/composables/useFullTable";
+import type { AnySearchResult } from "@/types/search";
+import { useHead } from "#imports";
+
+useHead({
+  title: "Leading Cases — CoLD",
+});
+
+const { data: leadingCases, isLoading, error } = useLeadingCases();
+</script>

--- a/frontend/app/pages/court-decision/leading-cases.vue
+++ b/frontend/app/pages/court-decision/leading-cases.vue
@@ -15,7 +15,7 @@
 
     <div v-else class="results-grid">
       <div
-        v-for="decision in enrichedLeadingCases"
+        v-for="decision in leadingCases"
         :key="String(decision.id || '')"
         class="result-item"
       >
@@ -29,12 +29,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
 import SearchResultCardContent from "@/components/search-results/SearchResultCardContent.vue";
 import LoadingCard from "@/components/layout/LoadingCard.vue";
 import InlineError from "@/components/ui/InlineError.vue";
 import { useLeadingCases } from "@/composables/useFullTable";
-import { useJurisdictionLookup } from "@/composables/useJurisdictions";
 import type { AnySearchResult } from "@/types/search";
 import { useHead } from "#imports";
 
@@ -43,15 +41,4 @@ useHead({
 });
 
 const { data: leadingCases, isLoading, error } = useLeadingCases();
-const { findJurisdictionByCode } = useJurisdictionLookup();
-
-const enrichedLeadingCases = computed(() =>
-  leadingCases.value?.map((decision) => ({
-    ...decision,
-    jurisdictions:
-      decision.jurisdictions ||
-      findJurisdictionByCode(decision.jurisdictionsAlpha3Code || "")?.name ||
-      null,
-  })),
-);
 </script>

--- a/frontend/app/pages/court-decision/leading-cases.vue
+++ b/frontend/app/pages/court-decision/leading-cases.vue
@@ -15,7 +15,7 @@
 
     <div v-else class="results-grid">
       <div
-        v-for="decision in leadingCases"
+        v-for="decision in enrichedLeadingCases"
         :key="String(decision.id || '')"
         class="result-item"
       >
@@ -29,10 +29,12 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from "vue";
 import SearchResultCardContent from "@/components/search-results/SearchResultCardContent.vue";
 import LoadingCard from "@/components/layout/LoadingCard.vue";
 import InlineError from "@/components/ui/InlineError.vue";
 import { useLeadingCases } from "@/composables/useFullTable";
+import { useJurisdictionLookup } from "@/composables/useJurisdictions";
 import type { AnySearchResult } from "@/types/search";
 import { useHead } from "#imports";
 
@@ -41,4 +43,15 @@ useHead({
 });
 
 const { data: leadingCases, isLoading, error } = useLeadingCases();
+const { findJurisdictionByCode } = useJurisdictionLookup();
+
+const enrichedLeadingCases = computed(() =>
+  leadingCases.value?.map((decision) => ({
+    ...decision,
+    jurisdictions:
+      decision.jurisdictions ||
+      findJurisdictionByCode(decision.jurisdictionsAlpha3Code || "")?.name ||
+      null,
+  })),
+);
 </script>

--- a/frontend/app/utils/jurisdictionParser.ts
+++ b/frontend/app/utils/jurisdictionParser.ts
@@ -1,3 +1,23 @@
+const COLD_ID_ALPHA3_PATTERN = /^[A-Z]+-([A-Z]{3})-/;
+
+/**
+ * Extracts the primary jurisdiction alpha-3 code from an entity record by
+ * preferring an explicit `jurisdictionsAlpha3Code` and falling back to the
+ * alpha-3 segment of its CoLD ID (e.g., "CD-DEU-362" → "DEU").
+ */
+export function primaryJurisdictionAlpha3(record: {
+  jurisdictionsAlpha3Code?: unknown;
+  coldId?: unknown;
+  id?: unknown;
+}): string {
+  const explicit = String(record.jurisdictionsAlpha3Code || "");
+  if (explicit) return explicit.toUpperCase();
+  const fromColdId = String(record.coldId || record.id || "").match(
+    COLD_ID_ALPHA3_PATTERN,
+  );
+  return fromColdId?.[1] ?? "";
+}
+
 /**
  * Parses a jurisdiction string that may contain single or multiple jurisdictions.
  * Handles jurisdiction names that contain commas (e.g., "Congo, the Democratic Republic of the")


### PR DESCRIPTION
Closes #467.

## Summary
- Adds `/court-decision/leading-cases` rendering all rank-10 court decisions as search cards; homepage card caps at 6 with the title linking to the new page.
- Backend: `/search/full_table` and `/search/filtered_table` now LEFT JOIN the FTS materialized views to enrich responses with `jurisdictions`/`themes`/`question` (Answers, HCCH Answers, Court Decisions, Domestic Instruments, Literature). Previously only `jurisdictionsAlpha3Code` was exposed.
- Frontend: `CardHeader` and `EntityDrawer` now pick the primary jurisdiction on multi-jurisdiction records (e.g. CD-DEU-362 → "European Union" + "Germany" → 🇩🇪 GERMANY) by resolving the alpha-3 from `jurisdictionsAlpha3Code` or the coldId segment via a shared `primaryJurisdictionAlpha3` helper.

## Test plan
- [ ] Homepage Leading Cases card shows up to 6 entries; clicking the title opens `/court-decision/leading-cases`.
- [ ] `/court-decision/leading-cases` renders every rank-10 court decision as a search card with jurisdiction flag + theme tags.
- [ ] `/court-decision/CD-DEU-362` (detail page) and the entity drawer for the same record both show the 🇩🇪 Germany pill instead of nothing.
- [ ] Spot-check Domestic Instruments / Literature search cards still render jurisdictions correctly via `/search`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)