### PR TITLE
fix(origin): allow Vercel branch and production URLs in CORS validation

### DIFF
--- a/frontend/server/utils/validateOrigin.test.ts
+++ b/frontend/server/utils/validateOrigin.test.ts
@@ -26,13 +26,23 @@ function makeConfig(siteUrl = "https://cold.global", additionalOrigins = "") {
 }
 
 describe("buildAllowedOrigins", () => {
-  const originalEnv = process.env.VERCEL_URL;
+  const VERCEL_ENV_KEYS = [
+    "VERCEL_URL",
+    "VERCEL_BRANCH_URL",
+    "VERCEL_PROJECT_PRODUCTION_URL",
+  ] as const;
+  const originalEnv = Object.fromEntries(
+    VERCEL_ENV_KEYS.map((key) => [key, process.env[key]]),
+  );
 
   afterEach(() => {
-    if (originalEnv === undefined) {
-      delete process.env.VERCEL_URL;
-    } else {
-      process.env.VERCEL_URL = originalEnv;
+    for (const key of VERCEL_ENV_KEYS) {
+      const value = originalEnv[key];
+      if (value === undefined) {
+        Reflect.deleteProperty(process.env, key);
+      } else {
+        process.env[key] = value;
+      }
     }
   });
 
@@ -54,6 +64,17 @@ describe("buildAllowedOrigins", () => {
     expect(origins).toContain("https://cold.global");
     expect(origins).toContain("https://www.cold.global");
     expect(origins).toContain("https://my-app-abc123.vercel.app");
+  });
+
+  it("includes VERCEL_BRANCH_URL and VERCEL_PROJECT_PRODUCTION_URL when set", () => {
+    process.env.VERCEL_BRANCH_URL =
+      "cold-web-app-git-issue-465-colds-projects-ae07faa5.vercel.app";
+    process.env.VERCEL_PROJECT_PRODUCTION_URL = "cold-web-app.vercel.app";
+    const origins = buildAllowedOrigins(makeConfig("https://cold.global"));
+    expect(origins).toContain(
+      "https://cold-web-app-git-issue-465-colds-projects-ae07faa5.vercel.app",
+    );
+    expect(origins).toContain("https://cold-web-app.vercel.app");
   });
 
   it("preserves port in www variant", () => {

--- a/frontend/server/utils/validateOrigin.ts
+++ b/frontend/server/utils/validateOrigin.ts
@@ -40,9 +40,15 @@ export function buildAllowedOrigins(config: {
     }
   }
 
-  const vercelUrl = process.env.VERCEL_URL;
-  if (vercelUrl) {
-    origins.push(`https://${vercelUrl}`);
+  const vercelHosts = [
+    process.env.VERCEL_URL,
+    process.env.VERCEL_BRANCH_URL,
+    process.env.VERCEL_PROJECT_PRODUCTION_URL,
+  ];
+  for (const host of vercelHosts) {
+    if (host) {
+      origins.push(`https://${host}`);
+    }
   }
 
   return origins;


### PR DESCRIPTION
## Summary

- Vercel preview deployments are reachable via multiple hostnames (unique `VERCEL_URL`, git-branch alias `VERCEL_BRANCH_URL`, and the project's production URL `VERCEL_PROJECT_PRODUCTION_URL`). The origin validator only allowed `VERCEL_URL`, so requests from the git-branch alias (e.g. `cold-web-app-git-issue-465-colds-projects-ae07faa5.vercel.app`) were rejected with `403 Forbidden: Invalid origin`.
- `buildAllowedOrigins` now also includes `VERCEL_BRANCH_URL` and `VERCEL_PROJECT_PRODUCTION_URL` when present.

## Test plan

- [x] `pnpm run check` (format, eslint, vue-tsc, vitest) — passes locally
- [ ] After deploy, hit the git-branch preview URL and confirm `/api/proxy/search/` no longer returns `403 Forbidden: Invalid origin`
- [ ] Confirm requests from the unique `VERCEL_URL` deployment URL still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)