### PR TITLE
fix(compatible-label): use w-fit instead of fixed width for HCCH Principles card

### DIFF
--- a/frontend/app/components/ui/CompatibleLabel.vue
+++ b/frontend/app/components/ui/CompatibleLabel.vue
@@ -1,5 +1,7 @@
 <template>
-  <span class="label-compatible inline-flex w-[126px] items-center">
+  <span
+    class="label-compatible inline-flex w-fit items-center whitespace-nowrap"
+  >
     <UIcon name="i-material-symbols:balance" class="icon-fixed mr-2" />
     {{ label }}
   </span>


### PR DESCRIPTION
Fixes #466.

The `CompatibleLabel` component had a hardcoded `w-[126px]` that caused the HCCH Principles mini card to render at an incorrect size. Replaced with `w-fit` and `whitespace-nowrap` so both the "HCCH Principles" and "UNCITRAL Model Law" labels size naturally to their content.