### PR TITLE
chore(frontend): pre-bundle @vue-leaflet/vue-leaflet via vite optimizeDeps

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -49,6 +49,7 @@ export default defineNuxtConfig({
         "mitt",
         "openapi-fetch",
         "date-fns",
+        "@vue-leaflet/vue-leaflet",
       ],
       exclude: ["@opentelemetry/api"],
     },


### PR DESCRIPTION
## Summary
- Add `@vue-leaflet/vue-leaflet` to `vite.optimizeDeps.include` in `frontend/nuxt.config.ts` so it is pre-bundled and avoids dev-time page reloads when first imported.

## Test plan
- [x] `pnpm run check` (format, lint, typecheck, vitest) passes
- [ ] Verify map pages load in dev without a forced reload after a cold start

🤖 Generated with [Claude Code](https://claude.com/claude-code)