### PR TITLE
fix(case-analyzer): render analyzer page for non-auth users

### DIFF
--- a/frontend/app/pages/court-decision/new.vue
+++ b/frontend/app/pages/court-decision/new.vue
@@ -157,10 +157,6 @@ import AnalysisStepTracker from "@/components/case-analyzer/AnalysisStepTracker.
 import PageHero from "@/components/ui/PageHero.vue";
 import AnalyzerIllustration from "@/components/case-analyzer/AnalyzerIllustration.vue";
 
-definePageMeta({
-  middleware: ["auth"],
-});
-
 useHead({ title: "AI Case Analyzer — CoLD" });
 
 const user = useUser();


### PR DESCRIPTION
## Summary
- Removes the `auth` middleware from `/court-decision/new` so the page renders for unauthenticated users.
- Existing in-page login notice already gates the upload action, so non-auth users see the layout (hero, step tracker, login prompt) and are only required to log in when they try to interact.

## Test plan
- [ ] Visit `/court-decision/new` while logged out — page renders with login notice instead of redirecting.
- [ ] Visit while logged in — upload flow works as before.