### PR TITLE
feat(frontend): cleaner UI (borderless cards, hairline inputs, sans headings)

### DIFF
--- a/frontend/app/app.config.ts
+++ b/frontend/app/app.config.ts
@@ -33,7 +33,7 @@ export default defineAppConfig({
           color: "neutral" as const,
           variant: "soft" as const,
           class: {
-            base: "landing-item-button flex w-full overflow-hidden rounded-lg shadow-xs [background:var(--gradient-subtle)] gap-3 py-3 px-4 pl-5 text-left font-medium transition-all duration-150 hover:shadow-sm hover:[background:var(--gradient-subtle-emphasis)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-cold-purple)]",
+            base: "landing-item-button flex w-full overflow-hidden rounded-lg [background:var(--gradient-subtle)] gap-3 py-3 px-4 pl-5 text-left font-medium transition-all duration-150 hover:shadow-xs hover:[background:var(--gradient-subtle-emphasis)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-cold-purple)]",
             label: "contents",
             leadingIcon:
               "h-3 w-3 mr-1.5 opacity-100 transition-[width,margin,opacity] duration-200 group-hover:w-0 group-hover:mr-0 group-hover:opacity-0",
@@ -45,7 +45,7 @@ export default defineAppConfig({
           color: "primary" as const,
           variant: "ghost" as const,
           class: {
-            base: "group cursor-pointer gap-0 rounded-lg px-3 py-1.5 text-sm font-medium shadow-xs ring-0 [background:var(--gradient-subtle)] text-[var(--color-cold-night)] transition-all duration-150 hover:[background:white] hover:shadow-sm hover:text-[var(--color-cold-purple)] hover:ring-0",
+            base: "group cursor-pointer gap-0 rounded-lg px-3 py-1.5 text-sm font-medium ring-0 [background:var(--gradient-subtle)] text-[var(--color-cold-night)] transition-all duration-150 hover:[background:white] hover:shadow-xs hover:text-[var(--color-cold-purple)] hover:ring-0",
             leadingIcon:
               "h-4 w-4 mr-2 shrink-0 opacity-100 transition-[width,margin,opacity] duration-200 group-hover:w-0 group-hover:mr-0 group-hover:opacity-0",
             trailingIcon:
@@ -62,20 +62,20 @@ export default defineAppConfig({
     input: {
       slots: {
         root: "w-full",
-        base: "h-[42px] px-3 border border-gray-200 rounded-lg bg-white text-[var(--color-cold-night)] text-sm leading-[1.4] shadow-xs transition-all duration-150 placeholder:text-[var(--color-cold-night-alpha-50,#8193a8)] hover:border-gray-300 hover:shadow-sm focus:border-[var(--color-cold-purple)] focus:bg-white focus:shadow-sm disabled:bg-[var(--color-cold-gray-alpha)] disabled:text-[var(--color-cold-night-alpha)] disabled:cursor-not-allowed",
+        base: "h-[42px] px-3 border border-black/[0.06] rounded-lg bg-white text-[var(--color-cold-night)] text-sm leading-[1.4] transition-all duration-150 placeholder:text-[var(--color-cold-night-alpha-50,#8193a8)] hover:border-black/[0.12] focus:border-[var(--color-cold-purple)] focus:bg-white disabled:bg-[var(--color-cold-gray-alpha)] disabled:text-[var(--color-cold-night-alpha)] disabled:cursor-not-allowed",
       },
     },
     textarea: {
       slots: {
         root: "w-full",
-        base: "min-h-24 px-3 py-2.5 border border-gray-200 rounded-lg bg-white text-[var(--color-cold-night)] text-sm leading-[1.4] shadow-xs transition-all duration-150 resize-y placeholder:text-[var(--color-cold-night-alpha-50,#8193a8)] hover:border-gray-300 hover:shadow-sm focus:border-[var(--color-cold-purple)] focus:bg-white focus:shadow-sm disabled:bg-[var(--color-cold-gray-alpha)] disabled:text-[var(--color-cold-night-alpha)] disabled:cursor-not-allowed",
+        base: "min-h-24 px-3 py-2.5 border border-black/[0.06] rounded-lg bg-white text-[var(--color-cold-night)] text-sm leading-[1.4] transition-all duration-150 resize-y placeholder:text-[var(--color-cold-night-alpha-50,#8193a8)] hover:border-black/[0.12] focus:border-[var(--color-cold-purple)] focus:bg-white disabled:bg-[var(--color-cold-gray-alpha)] disabled:text-[var(--color-cold-night-alpha)] disabled:cursor-not-allowed",
       },
     },
     select: {
       variants: {
         variant: {
           outline:
-            "bg-white shadow-xs border border-gray-200 hover:border-gray-300 hover:shadow-sm focus:border-[var(--color-cold-purple)] focus:ring-0 transition-all duration-150",
+            "bg-white border border-black/[0.06] hover:border-black/[0.12] focus:border-[var(--color-cold-purple)] focus:ring-0 transition-all duration-150",
         },
       },
     },
@@ -83,18 +83,28 @@ export default defineAppConfig({
       variants: {
         variant: {
           outline:
-            "bg-white shadow-xs border border-gray-200 hover:border-gray-300 hover:shadow-sm focus:border-[var(--color-cold-purple)] focus:ring-0 transition-all duration-150",
+            "bg-white border border-black/[0.06] hover:border-black/[0.12] focus:border-[var(--color-cold-purple)] focus:ring-0 transition-all duration-150",
         },
       },
       slots: {
-        content: "bg-white rounded-lg shadow-lg border border-gray-200 p-1",
+        content: "bg-white rounded-lg shadow-md border border-black/[0.06] p-1",
         item: "rounded-md px-2.5 py-2 cursor-pointer transition-colors data-highlighted:bg-[var(--gradient-subtle-hover)]",
-        input: "border-b border-gray-200 bg-white",
+        input: "border-b border-black/[0.06] bg-white",
       },
     },
     card: {
       slots: {
         root: "rounded-lg overflow-hidden relative bg-white border-0 ring-0",
+      },
+      variants: {
+        variant: {
+          outline: {
+            root: "bg-white ring-0 divide-y-0",
+          },
+          subtle: {
+            root: "ring-0",
+          },
+        },
       },
     },
   },

--- a/frontend/app/assets/styles.css
+++ b/frontend/app/assets/styles.css
@@ -249,12 +249,6 @@
     color: var(--color-cold-night);
   }
 
-  h1,
-  h2,
-  h3 {
-    font-family: "DM Serif Display", Georgia, serif;
-  }
-
   a {
     color: var(--color-cold-purple);
     text-decoration: none;
@@ -771,9 +765,9 @@ li::marker {
 }
 
 .comparison-title {
-  font-family: "DM Serif Display", Georgia, serif;
+  font-family: "DM Sans", sans-serif;
   font-size: 1.25rem;
-  font-weight: 400;
+  font-weight: 600;
   line-height: 1.3;
   color: var(--color-cold-night);
   letter-spacing: -0.01em;

--- a/frontend/app/components/event/EventSession.vue
+++ b/frontend/app/components/event/EventSession.vue
@@ -19,9 +19,7 @@
       >
         {{ tag }}
       </span>
-      <h3
-        class="text-cold-night mb-1.5 font-serif text-lg leading-snug font-bold"
-      >
+      <h3 class="text-cold-night mb-1.5 text-lg leading-snug font-bold">
         {{ title }}
       </h3>
       <div class="text-cold-charcoal text-sm leading-relaxed font-light">

--- a/frontend/app/components/search-results/SearchFilters.vue
+++ b/frontend/app/components/search-results/SearchFilters.vue
@@ -222,7 +222,7 @@ const hasActiveFilter = computed(() =>
 
 const filterUi = computed(() => ({
   base: hasActiveFilter.value
-    ? "border-[var(--color-cold-purple)] text-[var(--color-cold-purple)] bg-[var(--gradient-subtle)]"
+    ? "border-[var(--color-cold-purple)] text-[var(--color-cold-purple)]"
     : "",
 }));
 

--- a/frontend/app/components/ui/RelatedItemsList.test.ts
+++ b/frontend/app/components/ui/RelatedItemsList.test.ts
@@ -32,7 +32,7 @@ describe("RelatedItemsList", () => {
     expect(wrapper.findComponent({ name: "LoadingBar" }).exists()).toBe(true);
   });
 
-  it("displays only first 10 items initially when more than 10 items", () => {
+  it("renders all items even when many", () => {
     const manyItems = Array.from({ length: 15 }, (_, i) => ({
       id: `${i + 1}`,
       title: `Item ${i + 1}`,
@@ -47,79 +47,11 @@ describe("RelatedItemsList", () => {
 
     expect(wrapper.text()).toContain("Item 1");
     expect(wrapper.text()).toContain("Item 10");
-    expect(wrapper.text()).not.toContain("Item 11");
-  });
-
-  it("shows 'Show more' button when more than 10 items", () => {
-    const manyItems = Array.from({ length: 15 }, (_, i) => ({
-      id: `${i + 1}`,
-      title: `Item ${i + 1}`,
-    }));
-
-    const wrapper = mount(RelatedItemsList, {
-      props: {
-        items: manyItems,
-        basePath: "/test",
-      },
-    });
-
-    expect(wrapper.findComponent({ name: "ShowMoreLess" }).exists()).toBe(true);
-  });
-
-  it("does not show button when 10 or fewer items", () => {
-    const wrapper = mount(RelatedItemsList, {
-      props: {
-        items: mockItems,
-        basePath: "/test",
-      },
-    });
-
+    expect(wrapper.text()).toContain("Item 11");
+    expect(wrapper.text()).toContain("Item 15");
     expect(wrapper.findComponent({ name: "ShowMoreLess" }).exists()).toBe(
       false,
     );
-  });
-
-  it("toggles to show all items when clicking show more", async () => {
-    const manyItems = Array.from({ length: 15 }, (_, i) => ({
-      id: `${i + 1}`,
-      title: `Item ${i + 1}`,
-    }));
-
-    const wrapper = mount(RelatedItemsList, {
-      props: {
-        items: manyItems,
-        basePath: "/test",
-      },
-    });
-
-    expect(wrapper.text()).not.toContain("Item 11");
-
-    const showMoreLess = wrapper.findComponent({ name: "ShowMoreLess" });
-    const button = showMoreLess.find("button");
-    await button.trigger("click");
-
-    expect(wrapper.text()).toContain("Item 11");
-    expect(wrapper.text()).toContain("Item 15");
-  });
-
-  it("hides extra items when clicking show less", async () => {
-    const manyItems = Array.from({ length: 15 }, (_, i) => ({
-      id: `${i + 1}`,
-      title: `Item ${i + 1}`,
-    }));
-
-    const wrapper = mount(RelatedItemsList, {
-      props: {
-        items: manyItems,
-        basePath: "/test",
-      },
-    });
-
-    const showMoreLess = wrapper.findComponent({ name: "ShowMoreLess" });
-    await showMoreLess.find("button").trigger("click"); // Show all
-    await showMoreLess.find("button").trigger("click"); // Show less
-
-    expect(wrapper.text()).not.toContain("Item 11");
   });
 
   it("constructs correct link paths with basePath", () => {
@@ -193,23 +125,6 @@ describe("RelatedItemsList", () => {
     });
 
     expect(wrapper.html()).toContain("link-chip--neutral");
-  });
-
-  it("applies link-chip--action class to show more button", () => {
-    const manyItems = Array.from({ length: 15 }, (_, i) => ({
-      id: `${i + 1}`,
-      title: `Item ${i + 1}`,
-    }));
-
-    const wrapper = mount(RelatedItemsList, {
-      props: {
-        items: manyItems,
-        basePath: "/test",
-      },
-    });
-
-    const showMoreLess = wrapper.findComponent({ name: "ShowMoreLess" });
-    expect(showMoreLess.props("buttonClass")).toBe("link-chip--action");
   });
 
   it("applies link-chip--neutral regardless of entity type", () => {

--- a/frontend/app/components/ui/RelatedItemsList.vue
+++ b/frontend/app/components/ui/RelatedItemsList.vue
@@ -4,10 +4,10 @@
       <LoadingBar />
     </div>
     <InlineError v-else-if="error" :error="error" />
-    <div v-else-if="displayedItems.length" class="result-value-small">
+    <div v-else-if="items.length" class="result-value-small">
       <div class="mb-2 flex flex-row flex-wrap gap-x-6 gap-y-2">
         <EntityLink
-          v-for="item in displayedItems"
+          v-for="item in items"
           :key="item.id"
           :id="item.id"
           :title="item.title"
@@ -15,11 +15,6 @@
           :badge="item.badge"
         />
       </div>
-      <ShowMoreLess
-        v-if="items.length > 10"
-        v-model:is-expanded="showAll"
-        button-class="link-chip--action"
-      />
     </div>
     <p
       v-else-if="emptyValueBehavior.action === 'display'"
@@ -31,10 +26,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from "vue";
+import { computed } from "vue";
 import LoadingBar from "@/components/layout/LoadingBar.vue";
 import InlineError from "@/components/ui/InlineError.vue";
-import ShowMoreLess from "@/components/ui/ShowMoreLess.vue";
 import EntityLink from "@/components/ui/EntityLink.vue";
 import type { RelatedItem, EmptyValueBehavior } from "@/types/ui";
 
@@ -56,8 +50,6 @@ const props = withDefaults(
   },
 );
 
-const showAll = ref(false);
-
 const hasItems = computed(() => props.items.length > 0);
 
 const shouldShowSection = computed(
@@ -66,10 +58,4 @@ const shouldShowSection = computed(
     hasItems.value ||
     (!hasItems.value && props.emptyValueBehavior.action === "display"),
 );
-
-const displayedItems = computed(() => {
-  return !showAll.value && props.items.length > 10
-    ? props.items.slice(0, 10)
-    : props.items;
-});
 </script>

--- a/frontend/app/pages/event/launch.vue
+++ b/frontend/app/pages/event/launch.vue
@@ -15,7 +15,7 @@
             Online via Zoom &middot; Free &amp; Open
           </p>
           <h1
-            class="text-cold-night mt-4 font-serif text-4xl leading-tight font-bold sm:text-5xl"
+            class="text-cold-night mt-4 text-4xl leading-tight font-bold sm:text-5xl"
           >
             Choice of Law Dataverse in Action
           </h1>

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -122,11 +122,6 @@ export default defineNuxtConfig({
   fonts: {
     families: [
       {
-        name: "DM Serif Display",
-        provider: "google",
-        weights: [400],
-      },
-      {
         name: "DM Sans",
         provider: "google",
         weights: [300, 400, 500, 600, 700],


### PR DESCRIPTION
## Summary

Visual refresh that calms the page chrome end-to-end:

- **Cards**: removed the outline ring + slot dividers on shared `<UCard>`.
- **Inputs / select / textarea**: replaced the `gray-200 + shadow-xs` outline with a 6%-black hairline (12% on hover); kept white bg so they still read as active.
- **Buttons**: dropped resting `shadow-xs` on the two soft/ghost variants; lighter shadow on hover.
- **Typography**: dropped `DM Serif Display` everywhere (h1/h2/h3, `.comparison-title`, `font-serif` headings on event pages); font is no longer fetched from Google.
- **Filters**: active `<USelectMenu>` filters now signal state via purple border + label only — the bg gradient tint that made selected vs. empty filters look mismatched is gone.
- **Related items**: render all entries instead of capping at 10 + show-more/less.

## Test plan
- [ ] Landing page: cards render flat with the gradient top border still in place.
- [ ] Comparison page: all three filter selects share the same white background regardless of selection state.
- [ ] Detail page with >10 relations: every entry visible, no show-more button.
- [ ] Event launch page + sessions render headings in DM Sans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)