### PR TITLE
refactor(frontend): borderless ghost style for PDF/Link title actions

### DIFF
--- a/frontend/app/components/entity/content/LiteratureContent.vue
+++ b/frontend/app/components/entity/content/LiteratureContent.vue
@@ -13,7 +13,6 @@
               />
               <SourceExternalLink
                 :source-url="sourceUrl"
-                :label="sourceLinkLabel"
                 :open-access="!!data.openAccessUrl"
               />
             </template>
@@ -98,10 +97,6 @@ const sourceUrl = computed(() => {
   if (props.data.openAccessUrl) return String(props.data.openAccessUrl);
   return String(props.data.url || "");
 });
-
-const sourceLinkLabel = computed(() =>
-  props.data.openAccessUrl ? "Open Access Link" : "Link",
-);
 
 const bibtexContent = computed(() => generateBibTeX(props.data));
 

--- a/frontend/app/components/sources/SourceExternalLink.vue
+++ b/frontend/app/components/sources/SourceExternalLink.vue
@@ -4,16 +4,16 @@
       v-if="sourceUrl"
       :to="sourceUrl as string"
       target="_blank"
-      variant="subtle"
-      color="secondary"
-      size="sm"
+      variant="ghost"
+      color="primary"
+      size="xs"
       :icon="openAccess ? undefined : 'i-material-symbols:open-in-new'"
-      :trailing-icon="openAccess ? undefined : 'i-material-symbols:open-in-new'"
+      trailing-icon="i-material-symbols:open-in-new"
       @click.stop
     >
       <template v-if="openAccess" #leading>
         <img
-          class="h-4 w-4"
+          class="mr-2 h-4 w-4 shrink-0 object-contain opacity-100 transition-[width,margin,opacity] duration-200 group-hover:mr-0 group-hover:w-0 group-hover:opacity-0"
           src="https://choiceoflaw.blob.core.windows.net/assets/Open_Access_logo_PLoS_transparent.svg"
           alt="Open Access Logo"
         />

--- a/frontend/app/components/ui/PdfLink.vue
+++ b/frontend/app/components/ui/PdfLink.vue
@@ -3,9 +3,9 @@
     <UButton
       :to="finalPdfUrl"
       target="_blank"
-      variant="subtle"
-      color="secondary"
-      size="sm"
+      variant="ghost"
+      color="primary"
+      size="xs"
       icon="i-material-symbols:picture-as-pdf-outline"
       trailing-icon="i-material-symbols:picture-as-pdf-outline"
       aria-label="Download PDF for record"


### PR DESCRIPTION
## Summary
- `SourceExternalLink` and `PdfLink` switch from `secondary/subtle` to `primary/ghost` — drops the green border, adopts the brand cold-purple, keeps the leading→trailing icon swap on hover.
- `SourceExternalLink` always renders just "Link"; the open-access logo now joins the same fade-cross transition (sized and aligned to the variant's `leadingIcon`).
- Removes the now-unused `sourceLinkLabel` computed in `LiteratureContent`.

## Test plan
- [ ] Open a literature record with `openAccessUrl`: button reads "Link", OA logo on the left, fades out and the open-in-new icon fades in on hover.
- [ ] Open a literature record without `openAccessUrl`: button reads "Link", open-in-new icon swaps sides on hover.
- [ ] Open any record with a PDF: PDF button is borderless, swaps icon side on hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)