### PR TITLE
feat(specialist): add specialists listing page

### DIFF
--- a/backend/app/schemas/records.py
+++ b/backend/app/schemas/records.py
@@ -482,6 +482,26 @@ class QuestionRecord(RecordBase):
     themes: str | None = None
 
 
+class SpecialistRecord(RecordBase):
+    specialist: str | None = None
+    affiliation: str | None = None
+    contact: str | None = None
+    bio: str | None = None
+    website: str | None = None
+    record_id: str | None = None
+    nc_order: str | None = None
+    nc_record_id: str | None = None
+    nc_record_hash: str | None = None
+    created: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    created_by: str | None = None
+    updated_by: str | None = None
+    jurisdictions: str | None = None
+    jurisdictions_alpha_3_code: str | None = None
+    jurisdictions_link: str | None = None
+
+
 TABLE_RECORD_MODELS: dict[str, type[RecordBase]] = {
     "Answers": AnswerRecord,
     "Court Decisions": CourtDecisionRecord,
@@ -498,6 +518,7 @@ TABLE_RECORD_MODELS: dict[str, type[RecordBase]] = {
     "Regional Legal Provisions": RegionalLegalProvisionRecord,
     "Jurisdictions": JurisdictionRecord,
     "Questions": QuestionRecord,
+    "Specialists": SpecialistRecord,
 }
 
 AnyRecord = (
@@ -516,6 +537,7 @@ AnyRecord = (
     | RegionalLegalProvisionRecord
     | JurisdictionRecord
     | QuestionRecord
+    | SpecialistRecord
     | RecordBase
 )
 

--- a/backend/app/services/search.py
+++ b/backend/app/services/search.py
@@ -42,6 +42,7 @@ class SearchService:
         "arbitration provision": "data_views.base_arbitral_provisions",
         "jurisdictions": "data_views.base_jurisdictions",
         "questions": "data_views.base_questions",
+        "specialists": "data_views.base_specialists",
     }
 
     _TABLE_TO_FTS_ENRICHMENT: dict[str, tuple[str, dict[str, str]]] = {

--- a/backend/tests/test_records.py
+++ b/backend/tests/test_records.py
@@ -45,8 +45,8 @@ class TestRecordBase:
 
 
 class TestTableRecordModels:
-    def test_all_15_entries(self):
-        assert len(TABLE_RECORD_MODELS) == 15
+    def test_all_16_entries(self):
+        assert len(TABLE_RECORD_MODELS) == 16
 
     def test_expected_table_names(self):
         expected = {
@@ -65,6 +65,7 @@ class TestTableRecordModels:
             "Regional Legal Provisions",
             "Jurisdictions",
             "Questions",
+            "Specialists",
         }
         assert set(TABLE_RECORD_MODELS.keys()) == expected
 

--- a/frontend/app/pages/specialist/index.vue
+++ b/frontend/app/pages/specialist/index.vue
@@ -1,0 +1,183 @@
+<template>
+  <BaseDetailLayout table="Specialists" :loading="isLoading" :data="resultData">
+    <template #full-width>
+      <div class="gradient-top-border" />
+      <div class="w-full px-6 py-6">
+        <div class="rules-table">
+          <UTable :columns="columns" :data="rows">
+            <template #specialist-cell="{ row }">
+              <NuxtLink
+                v-if="row.original.coldId"
+                :to="`/specialist/${row.original.coldId}`"
+                class="table-row-link"
+              >
+                <span
+                  class="result-value-small block truncate whitespace-nowrap"
+                  >{{ row.original.specialist }}</span
+                >
+              </NuxtLink>
+              <span
+                v-else
+                class="result-value-small block truncate whitespace-nowrap"
+                >{{ row.original.specialist }}</span
+              >
+            </template>
+            <template #affiliation-cell="{ row }">
+              <NuxtLink
+                v-if="row.original.coldId"
+                :to="`/specialist/${row.original.coldId}`"
+                class="table-row-link"
+              >
+                <span class="result-value-small">{{
+                  row.original.affiliation
+                }}</span>
+              </NuxtLink>
+              <span v-else class="result-value-small">{{
+                row.original.affiliation
+              }}</span>
+            </template>
+            <template #open-cell="{ row }">
+              <NuxtLink
+                v-if="row.original.coldId"
+                :to="`/specialist/${row.original.coldId}`"
+                class="table-row-link arrow-cell"
+              >
+                <UIcon
+                  name="i-material-symbols:arrow-forward"
+                  class="arrow-icon"
+                />
+              </NuxtLink>
+              <span v-else class="text-gray-400">—</span>
+            </template>
+          </UTable>
+        </div>
+      </div>
+    </template>
+  </BaseDetailLayout>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import BaseDetailLayout from "@/components/layout/BaseDetailLayout.vue";
+import { useFullTable } from "@/composables/useFullTable";
+import type { SpecialistResponse } from "@/types/entities/specialist";
+
+useHead({
+  title: "Specialists — CoLD",
+});
+
+const { data: rawData, isLoading } = useFullTable("Specialists");
+const resultData = null;
+
+const columns = [
+  { id: "specialist", accessorKey: "specialist", header: "Name" },
+  { id: "affiliation", accessorKey: "affiliation", header: "Affiliation" },
+  { id: "open", accessorKey: "coldId", header: "" },
+];
+
+const sanitize = (v: string | number | null | undefined) =>
+  !v || v === "NA" ? "" : String(v).trim();
+
+const rows = computed(() =>
+  (rawData.value || [])
+    .map((r: SpecialistResponse) => ({
+      specialist: sanitize(r.specialist),
+      affiliation: sanitize(r.affiliation),
+      coldId: sanitize(r.coldId),
+    }))
+    .filter((r) => Boolean(r.specialist))
+    .sort((a, b) =>
+      a.specialist.localeCompare(b.specialist, undefined, {
+        sensitivity: "base",
+      }),
+    ),
+);
+</script>
+
+<style scoped>
+.rules-table :deep(table) {
+  table-layout: fixed;
+  width: 100%;
+}
+
+.rules-table :deep(th),
+.rules-table :deep(td) {
+  box-sizing: border-box;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding-right: 16px;
+}
+
+.rules-table :deep(th:first-child),
+.rules-table :deep(td:first-child) {
+  width: 40%;
+}
+
+.rules-table :deep(th:nth-child(2)),
+.rules-table :deep(td:nth-child(2)) {
+  width: auto;
+}
+
+.rules-table :deep(th:last-child),
+.rules-table :deep(td:last-child) {
+  width: 80px;
+  min-width: 80px;
+  max-width: 80px;
+  padding-right: 16px;
+  text-align: right;
+}
+
+.rules-table :deep(td:last-child a.label) {
+  font-weight: 600;
+  font-size: 12px;
+}
+
+.rules-table :deep(tbody tr) {
+  height: 72px;
+}
+.rules-table :deep(tbody td) {
+  height: 72px;
+  vertical-align: middle;
+}
+
+.rules-table :deep(tbody tr:hover) {
+  background-color: rgba(0, 0, 0, 0.02);
+  cursor: pointer;
+}
+
+.rules-table :deep(tbody tr:hover .arrow-icon) {
+  animation: bounce-right 0.4s ease-out;
+}
+
+.rules-table :deep(thead th) {
+  font-weight: 700;
+  font-size: 12px;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+  color: var(--color-cold-night);
+}
+
+.rules-table :deep(thead th span),
+.rules-table :deep(thead th button),
+.rules-table :deep(thead th button span) {
+  font-weight: 700;
+  font-size: 12px;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+  color: var(--color-cold-night);
+}
+
+.rules-table :deep(thead th button:hover),
+.rules-table :deep(thead th a:hover) {
+  background-color: transparent;
+  color: inherit;
+  text-decoration: none;
+  box-shadow: none;
+}
+.rules-table :deep(thead th button:hover span),
+.rules-table :deep(thead th a:hover span) {
+  color: inherit;
+  text-decoration: none;
+}
+</style>

--- a/frontend/app/types/api-schema.d.ts
+++ b/frontend/app/types/api-schema.d.ts
@@ -2695,6 +2695,30 @@ export interface components {
       bio?: string | null;
       website?: string | null;
     };
+    /** SpecialistRecord */
+    SpecialistRecord: {
+      sourceTable?: string | null;
+      id?: string | number | null;
+      coldId?: string | null;
+      rank?: number | null;
+      specialist?: string | null;
+      affiliation?: string | null;
+      contact?: string | null;
+      bio?: string | null;
+      website?: string | null;
+      recordId?: string | null;
+      ncOrder?: string | null;
+      ncRecordId?: string | null;
+      ncRecordHash?: string | null;
+      created?: string | null;
+      createdAt?: string | null;
+      updatedAt?: string | null;
+      createdBy?: string | null;
+      updatedBy?: string | null;
+      jurisdictions?: string | null;
+      jurisdictionsAlpha3Code?: string | null;
+      jurisdictionsLink?: string | null;
+    };
     /** SpecialistRelation */
     SpecialistRelation: {
       id: number;
@@ -3029,6 +3053,7 @@ export interface operations {
             | components["schemas"]["RegionalLegalProvisionRecord"]
             | components["schemas"]["JurisdictionRecord"]
             | components["schemas"]["QuestionRecord"]
+            | components["schemas"]["SpecialistRecord"]
             | components["schemas"]["RecordBase"]
           )[];
         };

--- a/frontend/app/types/entities/specialist.ts
+++ b/frontend/app/types/entities/specialist.ts
@@ -1,6 +1,6 @@
 import type { components } from "@/types/api-schema";
 
-export type SpecialistResponse = components["schemas"]["SpecialistResponse"];
+export type SpecialistResponse = components["schemas"]["SpecialistRecord"];
 export type SpecialistDetailResponse =
   components["schemas"]["SpecialistDetail"];
 

--- a/frontend/app/types/openapi.json
+++ b/frontend/app/types/openapi.json
@@ -281,6 +281,9 @@
                         "$ref": "#/components/schemas/QuestionRecord"
                       },
                       {
+                        "$ref": "#/components/schemas/SpecialistRecord"
+                      },
+                      {
                         "$ref": "#/components/schemas/RecordBase"
                       }
                     ]
@@ -13885,6 +13888,225 @@
         "type": "object",
         "required": ["id", "sourceTable"],
         "title": "SpecialistDetail"
+      },
+      "SpecialistRecord": {
+        "properties": {
+          "sourceTable": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "coldId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "rank": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "specialist": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "affiliation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "contact": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "bio": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "website": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "recordId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "ncOrder": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "ncRecordId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "ncRecordHash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "created": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "createdAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "updatedAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "updatedBy": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "jurisdictions": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "jurisdictionsAlpha3Code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "jurisdictionsLink": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "SpecialistRecord"
       },
       "SpecialistRelation": {
         "properties": {


### PR DESCRIPTION
## Summary
- Adds `/specialist` index page following the arbitral-rule listing pattern (Name + Affiliation table, click-through to detail, sorted A→Z, filters out rows with empty names).
- Backend: adds `SpecialistRecord` Pydantic model + maps `Specialists` to `data_views.base_specialists` so `/search/full_table` returns full rows instead of stripping fields.
- Regenerates OpenAPI types and points `SpecialistResponse` at the new `SpecialistRecord` schema.

## Test plan
- [x] `frontend && pnpm run check`
- [x] `backend && make check`
- [x] Browser smoke: `/specialist` renders title and table; row links navigate to `/specialist/[coldId]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)