### PR TITLE
feat(jurisdiction-comparison): match indicator column and percentage aggregate

### DIFF
--- a/frontend/app/components/jurisdiction/JurisdictionComparisonTable.vue
+++ b/frontend/app/components/jurisdiction/JurisdictionComparisonTable.vue
@@ -68,6 +68,23 @@
               />
             </div>
           </div>
+
+          <div v-if="matchStats" class="comparison-match-stats">
+            <UIcon
+              name="i-material-symbols:check-circle-rounded"
+              class="comparison-match-stats__icon"
+            />
+            <span class="comparison-match-stats__value">
+              {{ matchStats.percentage }}%
+            </span>
+            <span class="comparison-match-stats__label">
+              matching answers
+              <span class="comparison-match-stats__detail">
+                ({{ matchStats.matching }} of {{ matchStats.total }}
+                {{ matchStats.total === 1 ? "question" : "questions" }})
+              </span>
+            </span>
+          </div>
         </div>
 
         <div
@@ -202,6 +219,11 @@
                   />
                 </button>
               </div>
+              <div
+                class="comparison-header-cell comparison-header-cell--match sticky top-0 bg-white py-3"
+                :class="isScrollable ? 'sticky-col-match' : ''"
+                aria-hidden="true"
+              />
 
               <div v-for="row in rows" :key="row.id" class="comparison-row">
                 <div
@@ -260,6 +282,28 @@
                   </UTooltip>
                   <span v-else class="text-gray-400">—</span>
                 </div>
+
+                <div
+                  class="comparison-cell comparison-cell--match"
+                  :class="isScrollable ? 'sticky-col-match' : ''"
+                >
+                  <USkeleton
+                    v-if="!allJurisdictionsHaveAnswersLoaded"
+                    class="h-4 w-4 rounded-full"
+                  />
+                  <UIcon
+                    v-else-if="row.matchStatus === 'match'"
+                    name="i-material-symbols:check-circle-rounded"
+                    class="match-indicator match-indicator--match"
+                    :title="`All ${jurisdictions.length} jurisdictions agree`"
+                  />
+                  <UIcon
+                    v-else-if="row.matchStatus === 'mismatch'"
+                    name="i-material-symbols:remove-rounded"
+                    class="match-indicator match-indicator--mismatch"
+                    title="Answers differ"
+                  />
+                </div>
               </div>
             </div>
           </div>
@@ -273,10 +317,31 @@
               :style="{ paddingLeft: `calc(1.5rem + ${row.level * 2}em)` }"
             >
               <div
-                class="mb-3 text-sm whitespace-pre-line"
+                class="mb-3 flex items-start gap-2 text-sm whitespace-pre-line"
                 :class="{ 'font-semibold': isBoldQuestion(row.id) }"
               >
-                {{ row.question }}
+                <span class="min-w-0 flex-1">{{ row.question }}</span>
+                <UIcon
+                  v-if="
+                    allJurisdictionsHaveAnswersLoaded &&
+                    row.matchStatus === 'match'
+                  "
+                  name="i-material-symbols:check-circle-rounded"
+                  class="match-indicator match-indicator--match mt-0.5 shrink-0"
+                />
+                <UIcon
+                  v-else-if="
+                    allJurisdictionsHaveAnswersLoaded &&
+                    row.matchStatus === 'mismatch'
+                  "
+                  name="i-material-symbols:remove-rounded"
+                  class="match-indicator match-indicator--mismatch mt-0.5 shrink-0"
+                />
+                <span
+                  v-else
+                  class="match-indicator match-indicator--spacer shrink-0"
+                  aria-hidden="true"
+                />
               </div>
 
               <div class="flex flex-wrap gap-4">
@@ -506,6 +571,8 @@ const useShortLabels = computed(() => jurisdictions.value.length >= 4);
 
 const isScrollable = computed(() => jurisdictions.value.length >= 5);
 
+const MATCH_COL_WIDTH = 44;
+
 const gridTemplateColumns = computed(() => {
   const count = jurisdictions.value.length;
   let questionCol: string;
@@ -521,7 +588,7 @@ const gridTemplateColumns = computed(() => {
     answerCol = "minmax(0, 1fr)";
   }
   const answerCols = Array(count).fill(answerCol).join(" ");
-  return `${questionCol} ${answerCols}`;
+  return `${questionCol} ${answerCols} ${MATCH_COL_WIDTH}px`;
 });
 
 const stickyColLeft = computed(() => {
@@ -547,6 +614,22 @@ const hasAnswersForJurisdiction = (coldId?: string) => {
   if (!coldId) return false;
   const upperCode = coldId.toUpperCase();
   return loadedJurisdictions.value.has(upperCode);
+};
+
+const allJurisdictionsHaveAnswersLoaded = computed(() =>
+  jurisdictionCodes.value.every((code) => hasAnswersForJurisdiction(code)),
+);
+
+type MatchStatus = "match" | "mismatch" | "na";
+
+const normalizeAnswerForMatch = (value: string) =>
+  !value || DASH_ANSWERS.has(value) ? "—" : value;
+
+const getMatchStatus = (answers: Record<string, string>): MatchStatus => {
+  const values = Object.values(answers);
+  if (values.length < 2) return "na";
+  const normalized = values.map(normalizeAnswerForMatch);
+  return new Set(normalized).size === 1 ? "match" : "mismatch";
 };
 
 const rows = computed(() => {
@@ -575,6 +658,8 @@ const rows = computed(() => {
         question: item.question,
         answer: answerDisplay,
         answerLink: `/question/${iso3}_${id}`,
+        answers: undefined,
+        matchStatus: "na" as MatchStatus,
         level,
       };
     }
@@ -592,10 +677,31 @@ const rows = computed(() => {
     return {
       id,
       question: item.question,
+      answer: undefined,
+      answerLink: undefined,
       answers,
+      matchStatus: getMatchStatus(answers),
       level,
     };
   });
+});
+
+const matchStats = computed(() => {
+  if (isSingleJurisdiction.value) return null;
+  if (!allJurisdictionsHaveAnswersLoaded.value) return null;
+  let total = 0;
+  let matching = 0;
+  for (const row of rows.value) {
+    if (row.matchStatus === "na") continue;
+    total++;
+    if (row.matchStatus === "match") matching++;
+  }
+  if (total === 0) return null;
+  return {
+    total,
+    matching,
+    percentage: Math.round((matching / total) * 100),
+  };
 });
 </script>
 
@@ -731,5 +837,77 @@ const rows = computed(() => {
   @apply shadow;
   background: var(--gradient-subtle-emphasis);
   color: var(--color-cold-purple);
+}
+
+.comparison-header-cell--match {
+  padding-inline: 0;
+}
+
+.comparison-cell--match {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 0;
+}
+
+.match-indicator {
+  width: 1.125rem;
+  height: 1.125rem;
+}
+
+.match-indicator--match {
+  color: var(--color-emerald-500, #10b981);
+}
+
+.match-indicator--mismatch {
+  color: var(--color-amber-500, #f59e0b);
+}
+
+.match-indicator--spacer {
+  display: inline-block;
+}
+
+.sticky-col-match {
+  position: sticky;
+  right: 0;
+  z-index: 35;
+  background: white;
+}
+
+.comparison-row:hover .sticky-col-match {
+  background: inherit;
+}
+
+.comparison-match-stats {
+  margin-top: 0.875rem;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.5rem 0.875rem;
+  border-radius: 6px;
+  background: var(--gradient-subtle);
+}
+
+.comparison-match-stats__icon {
+  position: relative;
+  top: 2px;
+  width: 1rem;
+  height: 1rem;
+  color: var(--color-emerald-500, #10b981);
+}
+
+.comparison-match-stats__value {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-cold-night);
+}
+
+.comparison-match-stats__label {
+  font-size: 0.8125rem;
+  color: var(--color-cold-night-alpha);
+}
+
+.comparison-match-stats__detail {
+  font-size: 0.75rem;
 }
 </style>


### PR DESCRIPTION
## Summary

Adds a right-end column to the jurisdiction comparison grid showing whether all jurisdictions agree on each question (green check) or differ (amber dash), plus an aggregate badge under the selector showing the matching-answer percentage and count. Empty / "Not applicable" / "No information" answers normalize to a dash and are compared like any other value, so a missing answer next to a real one counts as a mismatch. Indicators are hidden until every jurisdiction's answers have loaded so values don't flicker. The mobile multi-jurisdiction view shows the indicator inline at the right of each question; the single-jurisdiction view is unchanged.

## Test plan

- [ ] Single-jurisdiction view: no match column, no aggregate
- [ ] 2 jurisdictions: indicators + aggregate render correctly
- [ ] 5+ jurisdictions: indicator column stays sticky on the right while scrolling horizontally
- [ ] Rows with mixed real answer + dash: render as mismatch
- [ ] Mobile multi-jurisdiction: indicator shows after the question text

🤖 Generated with [Claude Code](https://claude.com/claude-code)