### PR TITLE
fix(frontend): fix logo/photo sizing and remove lightbox on prose images

### DIFF
--- a/frontend/app/assets/styles.css
+++ b/frontend/app/assets/styles.css
@@ -2035,11 +2035,10 @@ button.cold-toggle-btn[aria-pressed="true"] {
   margin-bottom: 1.25rem;
 }
 
-/* Images - constrain to reasonable size */
+/* Images - display at their specified width, prevent overflow */
 .content-page-prose img {
-  max-width: 200px;
+  max-width: 100%;
   height: auto;
-  border-radius: 0.375rem;
   margin-top: 1rem;
   margin-bottom: 1rem;
 }

--- a/frontend/app/components/ProseImg.vue
+++ b/frontend/app/components/ProseImg.vue
@@ -1,0 +1,21 @@
+<template>
+  <img
+    :src="src"
+    :alt="alt"
+    :style="
+      width
+        ? { width: `${width}px`, maxWidth: '100%', height: 'auto' }
+        : { maxWidth: '100%', height: 'auto' }
+    "
+    class="my-4 rounded-md"
+  />
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  src: string;
+  alt: string;
+  width?: string | number;
+  height?: string | number;
+}>();
+</script>

--- a/frontend/content/endorsements.md
+++ b/frontend/content/endorsements.md
@@ -2,7 +2,7 @@
 title: Endorsements — CoLD
 ---
 
-<img src="https://choiceoflaw.blob.core.windows.net/assets/hcch-logo.svg" width="80"/>
+<img src="https://choiceoflaw.blob.core.windows.net/assets/hcch-logo.svg" alt="HCCH logo" style="width: 80px"/>
 
 <a href="https://www.hcch.net/en/home" target="_blank">**The Hague Conference on Private International Law**<img
     src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
@@ -12,7 +12,7 @@ title: Endorsements — CoLD
 We count on the support of the Hague Conference on Private International Law (HCCH) and its wide network of specialists. This project will also follow the future work of the HCCH on the law applicable to international commercial contracts.
 <br><br><br>
 
-<img src="https://choiceoflaw.blob.core.windows.net/assets/university-of-johannesburg-logo.svg" width="100"/>
+<img src="https://choiceoflaw.blob.core.windows.net/assets/university-of-johannesburg-logo.svg" alt="University of Johannesburg logo" style="width: 100px"/>
 
 <a href="https://www.uj.ac.za/faculties/law/research-centre-for-private-international-law-in-emerging-countries/" target="_blank">**The Research Centre for Private International Law in Emerging Countries**<img
     src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
@@ -21,7 +21,7 @@ We count on the support of the Hague Conference on Private International Law (HC
   /></a>  
 Led by Prof Jan L Neels and Prof Eesa A Fredericks (Project Partners), the Research Centre for Private International Law in Emerging Countries at the University of Johannesburg develops studies on the harmonization of international commercial law, most notably the African Principles on the Law Applicable to International Commercial Contracts.  
 <br><br><br>
-<img src="https://choiceoflaw.blob.core.windows.net/assets/universite-de-montreal-logo.svg" width="150"/>
+<img src="https://choiceoflaw.blob.core.windows.net/assets/universite-de-montreal-logo.svg" alt="Université de Montréal logo" style="width: 150px"/>
 
 <a href="https://www.umontreal.ca/" target="_blank">**Université de Montréal**<img
     src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
@@ -30,7 +30,7 @@ Led by Prof Jan L Neels and Prof Eesa A Fredericks (Project Partners), the Resea
   /></a>  
 Prof Geneviève Saumier is the dean of the Faculty of Law of the Université de Montréal and also serves as a Project Partner for the Dataverse. She has worked closely with the HCCH and has developed numerous studies on private international law.
 <br><br><br>
-<img src="https://choiceoflaw.blob.core.windows.net/assets/cedep-logo.svg" width="120"/>
+<img src="https://choiceoflaw.blob.core.windows.net/assets/cedep-logo.svg" alt="CEDEP logo" style="width: 120px"/>
 
 <a href="https://e-cedep.cedep.org.py/" target="_blank">**CEDEP**<img
     src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
@@ -39,7 +39,7 @@ Prof Geneviève Saumier is the dean of the Faculty of Law of the Université de 
   /></a>  
 CEDEP is a research institute with global outreach that promotes courses and events closely related to the studies developed by this project.
 <br><br><br>
-<img src="https://choiceoflaw.blob.core.windows.net/assets/universitaet-luzern-logo.svg" width="170"/>
+<img src="https://choiceoflaw.blob.core.windows.net/assets/universitaet-luzern-logo.svg" alt="Universität Luzern logo" style="width: 170px"/>
 
 <a href="https://www.unilu.ch/en/study/study-programmes/masters-degrees/faculty-of-humanities-and-social-sciences/lucerne-master-in-computational-social-sciences-lumacss/" target="_blank">**The Lucerne Master in Computational Social Sciences**<img
     src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"

--- a/frontend/content/supporters.md
+++ b/frontend/content/supporters.md
@@ -4,8 +4,9 @@ title: Supporters — CoLD
 
 ## Who Supports CoLD?
 
-- <img src="https://choiceoflaw.blob.core.windows.net/assets/snf-logo.svg" width="250"/>
-  Swiss National Science Foundation: “The Hague Principles and Beyond”, Project No. 179515 (2018–2021)
+<div><img src="https://choiceoflaw.blob.core.windows.net/assets/snf-logo.svg" alt="Swiss National Science Foundation logo" style="width: 250px; margin-bottom: 0.5rem"/></div>
+
+- Swiss National Science Foundation: “The Hague Principles and Beyond”, Project No. 179515 (2018–2021)
 - Forschungskommission der Universität Luzern: Start up funding (2022)
 - Swiss National Science Foundation: “Choice of Law Dataverse: promoting transparency and access in private international law data”, Project No. 215469 (2023-2026)
 - Provost's administrative support, University of Lucerne (2023-2026)

--- a/frontend/content/team.md
+++ b/frontend/content/team.md
@@ -4,7 +4,7 @@ title: Team — CoLD
 
 ## Core Team
 
-<img src="https://www.unilu.ch/fileadmin/_processed_/a/b/csm_Girsberger_Daniel_Q_d862e28b53.jpg" width="150"/>
+<img src="https://www.unilu.ch/fileadmin/_processed_/a/b/csm_Girsberger_Daniel_Q_d862e28b53.jpg" alt="Daniel Girsberger" style="width: 150px"/>
 
 **Daniel Girsberger** Project Leader
 
@@ -14,7 +14,7 @@ title: Team — CoLD
     class="external-link-icon"
   /></a> is the grant holder of the SNF Project. He oversees the strategic and operational decisions and is responsible for data quality control for the Dataverse. Daniel steers the Scientific Board, composed of legal experts from all continents.
 
-<img src="https://www.unilu.ch/fileadmin/_processed_/b/2/csm_Brandao_de_Oliveira_Agatha-1452-20230619_f5c03e5ebb.jpg" width="150"/>
+<img src="https://www.unilu.ch/fileadmin/_processed_/b/2/csm_Brandao_de_Oliveira_Agatha-1452-20230619_f5c03e5ebb.jpg" alt="Agatha Brandão de Oliveira" style="width: 150px"/>
 
 **Agatha Brandão de Oliveira** Project Coordinator
 
@@ -24,7 +24,7 @@ title: Team — CoLD
     class="external-link-icon"
   /></a> is responsible for the strategic vision and practical execution of the project. She manages a multidisciplinary staff and is in charge of fostering partnerships. Agatha also acts as a Senior Researcher for the Dataverse, with a focus on data input.
 
-<img src="https://www.unilu.ch/fileadmin/_processed_/e/f/csm_Tovar_Rorick_Q_b319006387.jpg" width="150"/>
+<img src="https://www.unilu.ch/fileadmin/_processed_/e/f/csm_Tovar_Rorick_Q_b319006387.jpg" alt="Rorick Daniel Tovar Galván" style="width: 150px"/>
 
 **Rorick Daniel Tovar Galván** Senior Researcher
 
@@ -34,7 +34,7 @@ title: Team — CoLD
     class="external-link-icon"
   /></a> holds a Ph.D. from the University of Bern, Switzerland. He oversees data input from Latin American countries into the Dataverse.
 
-<img src="https://www.unilu.ch/fileadmin/_processed_/d/8/csm_Ptitsina_Anna_Q_76218e9380.jpg" width="150"/>
+<img src="https://www.unilu.ch/fileadmin/_processed_/d/8/csm_Ptitsina_Anna_Q_76218e9380.jpg" alt="Anna Ptitsina" style="width: 150px"/>
 
 **Anna Ptitsina** Editorial Assistant
 
@@ -44,7 +44,7 @@ title: Team — CoLD
     class="external-link-icon"
   /></a> is in charge of integrating the Dataverse information into academic publications.
 
-<img src="https://www.unilu.ch/fileadmin/_processed_/3/c/csm_McMahon_Dominic-C_16574ec129.jpg" width="150"/>
+<img src="https://www.unilu.ch/fileadmin/_processed_/3/c/csm_McMahon_Dominic-C_16574ec129.jpg" alt="Dominic McMahon" style="width: 150px"/>
 
 **Dominic McMahon** Legal NLP Specialist & Data Analytics Lead
 


### PR DESCRIPTION
Fixes incorrect sizing of logos on the endorsements page and photos on the team page, where all images rendered at a uniform 200px due to Nuxt UI's `w-full` class overriding `width` HTML attributes.

Adds a custom `ProseImg.vue` component in the app layer to override Nuxt UI's `prose/Img`, removing the zoom/lightbox dialog entirely and converting the `width` prop to an inline style (which takes precedence over class-based width). Updates `endorsements.md`, `team.md`, and `supporters.md` to use inline `style="width: Xpx"` and proper `alt` attributes on all images. Removes the `max-width: 200px` constraint from `.content-page-prose img` in `styles.css`. The SNF logo on the supporters page is also fixed by wrapping it in a `<div>` block to ensure correct HTML block parsing and fixing curly quotes in the URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)