### PR TITLE
fix(views): add _sortable_date(date) overload so arbitral-institution detail loads

### DIFF
--- a/backend/alembic_views/versions/202604251200_sortable_date_date_overload.py
+++ b/backend/alembic_views/versions/202604251200_sortable_date_date_overload.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from alembic import op
+
+revision = "202604251200"
+down_revision = "202604251100"
+branch_labels = None
+depends_on = None
+
+
+SORTABLE_DATE_DATE_OVERLOAD = """
+CREATE OR REPLACE FUNCTION data_views._sortable_date(d DATE) RETURNS DATE AS $func$
+BEGIN
+    RETURN d;
+END;
+$func$ LANGUAGE plpgsql IMMUTABLE;
+"""
+
+
+DROP_SORTABLE_DATE_DATE_OVERLOAD = """
+DROP FUNCTION IF EXISTS data_views._sortable_date(DATE);
+"""
+
+
+def upgrade() -> None:
+    op.execute(SORTABLE_DATE_DATE_OVERLOAD)
+
+
+def downgrade() -> None:
+    op.execute(DROP_SORTABLE_DATE_DATE_OVERLOAD)


### PR DESCRIPTION
## Summary
- `get_entity_detail('Arbitral Institutions', ...)` aggregates `rel_arbitral_rules` ordered by `_sortable_date(r.in_force_from)`, but `in_force_from` is a `date` column while the helper only had a `(TEXT)` signature, so Postgres raised `function _sortable_date(date) does not exist` and every `/arbitral-institution/AI-*` detail call 404'd.
- New views migration `202604251200_sortable_date_date_overload.py` adds an idempotent `_sortable_date(DATE) RETURNS DATE` overload (returns input unchanged); existing TEXT callers are untouched.

## Test plan
- [ ] `alembic upgrade head` against the views DB
- [ ] `curl /api/v1/search/details {"table":"Arbitral Institutions","id":"AI-24"}` returns 200
- [ ] Open http://localhost:3000/arbitral-institution/AI-24 in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)