### PR TITLE
perf(homepage): paginate full_table and defer non-critical components

### DIFF
--- a/backend/app/routes/search.py
+++ b/backend/app/routes/search.py
@@ -165,15 +165,31 @@ def return_full_table(
     table = body.table
     filters = body.filters or []
     response_type = getattr(body, "response_type", "parsed")
+    order_by = body.order_by
+    order_dir = body.order_dir
+    limit = body.limit
 
     if not table:
         raise HTTPException(status_code=400, detail="No table provided")
 
     try:
         if filters:
-            results = search_service.filtered_table(table, filters, response_type=response_type)
+            results = search_service.filtered_table(
+                table,
+                filters,
+                response_type=response_type,
+                order_by=order_by,
+                order_dir=order_dir,
+                limit=limit,
+            )
         else:
-            results = search_service.full_table(table, response_type=response_type)
+            results = search_service.full_table(
+                table,
+                response_type=response_type,
+                order_by=order_by,
+                order_dir=order_dir,
+                limit=limit,
+            )
     except Exception as e:
         logger.exception("Failed to query table=%s filters=%d", table, len(filters))
         raise HTTPException(status_code=500, detail="Failed to query table") from e

--- a/backend/app/schemas/requests.py
+++ b/backend/app/schemas/requests.py
@@ -74,6 +74,20 @@ class FullTableRequest(BaseModel):
         "parsed",
         description="Response data format. Only 'parsed' is supported.",
     )
+    limit: int | None = Field(
+        None,
+        ge=1,
+        le=10000,
+        description="Maximum number of rows to return. Omit for no limit.",
+    )
+    order_by: str | None = Field(
+        None,
+        description="Column name to sort by (camelCase or snake_case). Unknown columns are ignored.",
+    )
+    order_dir: Literal["asc", "desc"] | None = Field(
+        "desc",
+        description="Sort direction when order_by is provided.",
+    )
     model_config = {
         "json_schema_extra": {
             "examples": [
@@ -81,6 +95,9 @@ class FullTableRequest(BaseModel):
                     "table": "Answers",
                     "filters": [{"column": "Jurisdictions", "value": "Switzerland"}],
                     "response_type": "parsed",
+                    "limit": 10,
+                    "order_by": "date",
+                    "order_dir": "desc",
                 },
             ]
         }

--- a/backend/app/services/search.py
+++ b/backend/app/services/search.py
@@ -2,11 +2,14 @@ import logging
 import re
 from typing import Any
 
+from pydantic.alias_generators import to_snake
+
 from app.config import config
 from app.services.database import Database
 from app.services.filter_builder import build_filter_clause
 
 _SAFE_IDENTIFIER = re.compile(r"^[a-z_][a-z0-9_.]*$")
+_SAFE_COLUMN = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
 logger = logging.getLogger(__name__)
 
@@ -86,11 +89,40 @@ class SearchService:
             return None
         return view, fields
 
-    def _build_select_sql(self, table: str, alias: str = "c", where_sql: str = "") -> str:
+    @staticmethod
+    def _build_order_clause(alias: str, order_by: str | None, order_dir: str | None) -> str:
+        if not order_by:
+            return ""
+        snake = to_snake(order_by)
+        if not _SAFE_COLUMN.match(snake):
+            return ""
+        direction = "ASC" if (order_dir or "desc").lower() == "asc" else "DESC"
+        return f' ORDER BY {alias}."{snake}" {direction} NULLS LAST'
+
+    @staticmethod
+    def _build_limit_clause(limit: int | None) -> str:
+        if limit is None or limit <= 0:
+            return ""
+        return f" LIMIT {int(limit)}"
+
+    def _build_select_sql(
+        self,
+        table: str,
+        alias: str = "c",
+        where_sql: str = "",
+        order_by: str | None = None,
+        order_dir: str | None = None,
+        limit: int | None = None,
+    ) -> str:
         view = self._complete_view_for_table(table)
         enrichment = self._fts_enrichment_for_table(table)
+        order_sql = self._build_order_clause(alias, order_by, order_dir)
+        limit_sql = self._build_limit_clause(limit)
         if enrichment is None:
-            return f"SELECT {alias}.id AS record_id, to_jsonb({alias}.*) AS complete_record FROM {view} {alias}{where_sql}"
+            return (
+                f"SELECT {alias}.id AS record_id, to_jsonb({alias}.*) AS complete_record "
+                f"FROM {view} {alias}{where_sql}{order_sql}{limit_sql}"
+            )
         fts_view, fields = enrichment
         pairs = ", ".join(f"'{key}', sv.\"{col}\"" for key, col in fields.items())
         return (
@@ -98,7 +130,7 @@ class SearchService:
             f"to_jsonb({alias}.*) || jsonb_build_object({pairs}) AS complete_record "
             f"FROM {view} {alias} "
             f"LEFT JOIN {fts_view} sv ON sv.id = {alias}.id"
-            f"{where_sql}"
+            f"{where_sql}{order_sql}{limit_sql}"
         )
 
     VALID_DETAIL_TABLES: set[str] = {
@@ -172,20 +204,47 @@ class SearchService:
                 results.append(flat)
         return results
 
-    def full_table(self, table: str, response_type: str = "parsed") -> list[dict[str, Any]]:
+    def full_table(
+        self,
+        table: str,
+        response_type: str = "parsed",
+        order_by: str | None = None,
+        order_dir: str | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
         try:
-            sql = self._build_select_sql(table)
+            sql = self._build_select_sql(
+                table,
+                order_by=order_by,
+                order_dir=order_dir,
+                limit=limit,
+            )
             rows = self.db.execute_query(sql, {}) or []
             return self._flatten_rows(rows, table, response_type)
         except Exception as e:
             logger.error("Error querying full table %s: %s", table, e)
             return []
 
-    def filtered_table(self, table: str, filters: list[Any], response_type: str = "parsed") -> list[dict[str, Any]]:
+    def filtered_table(
+        self,
+        table: str,
+        filters: list[Any],
+        response_type: str = "parsed",
+        order_by: str | None = None,
+        order_dir: str | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
         try:
             alias = "c"
             where_sql, params = build_filter_clause(alias, filters)
-            sql = self._build_select_sql(table, alias=alias, where_sql=where_sql)
+            sql = self._build_select_sql(
+                table,
+                alias=alias,
+                where_sql=where_sql,
+                order_by=order_by,
+                order_dir=order_dir,
+                limit=limit,
+            )
             rows = self.db.execute_query(sql, params) or []
             return self._flatten_rows(rows, table, response_type)
         except Exception as e:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -40,24 +40,13 @@ RUN NODE_OPTIONS="--max_old_space_size=4096" pnpm run build
 # ============================================
 FROM node:22.18-alpine
 
-# Set working directory
 WORKDIR /app
 
-# Install pnpm
-RUN npm install -g pnpm
-
-# Copy package manifest and lockfile
-COPY package.json pnpm-lock.yaml ./
-
-# Install only production dependencies
-RUN pnpm install --frozen-lockfile --prod
-
-# Copy built application from builder stage
-# This excludes all build-time secrets and source code
+# Nuxt's .output is self-contained (Nitro bundles all server deps),
+# so no extra `pnpm install` is needed in this stage.
 COPY --from=builder /app/.output ./.output
 
-# Expose the application port
+ENV NODE_ENV=production
 EXPOSE 3000
 
-# Command to run the app in production mode
 CMD ["node", "--max_old_space_size=2048", "./.output/server/index.mjs"]

--- a/frontend/app/app.vue
+++ b/frontend/app/app.vue
@@ -25,6 +25,11 @@ useHead({
   },
   link: [
     {
+      rel: "preconnect",
+      href: "https://choiceoflaw.blob.core.windows.net",
+      crossorigin: "",
+    },
+    {
       rel: "icon",
       type: "image/png",
       href: "/favicon-96x96.png",

--- a/frontend/app/components/landing-page/LeadingCases.vue
+++ b/frontend/app/components/landing-page/LeadingCases.vue
@@ -8,7 +8,7 @@
     header-class="cursor-pointer text-left md:whitespace-nowrap"
   >
     <FlagTitleYearItem
-      v-for="decision in leadingCases?.slice(0, 6)"
+      v-for="decision in leadingCases"
       :key="String(decision.id || '')"
       :to="`/court-decision/${decision.id}`"
       :iso3="decision.jurisdictionsAlpha3Code || ''"
@@ -29,5 +29,5 @@ import FlagTitleYearItem from "@/components/landing-page/FlagTitleYearItem.vue";
 import { useLeadingCases } from "@/composables/useFullTable";
 import { formatYear } from "@/utils/format";
 
-const { data: leadingCases, isLoading, error } = useLeadingCases();
+const { data: leadingCases, isLoading, error } = useLeadingCases({ limit: 6 });
 </script>

--- a/frontend/app/components/landing-page/RecentDomesticInstruments.vue
+++ b/frontend/app/components/landing-page/RecentDomesticInstruments.vue
@@ -8,7 +8,7 @@
     header-class="cursor-pointer text-left md:whitespace-nowrap"
   >
     <FlagTitleYearItem
-      v-for="instrument in domesticInstruments?.slice(0, 3)"
+      v-for="instrument in domesticInstruments"
       :key="String(instrument.id || '')"
       :to="`/domestic-instrument/${instrument.id}`"
       :iso3="instrument.jurisdictionsAlpha3Code || ''"
@@ -36,5 +36,6 @@ const {
   error,
 } = useDomesticInstruments({
   filterCompatible: ref(false),
+  limit: 3,
 });
 </script>

--- a/frontend/app/components/landing-page/SuccessfulLegalTransplantations.vue
+++ b/frontend/app/components/landing-page/SuccessfulLegalTransplantations.vue
@@ -6,7 +6,7 @@
     :error="error"
   >
     <FlagTitleYearItem
-      v-for="instrument in domesticInstruments?.slice(0, 9)"
+      v-for="instrument in domesticInstruments"
       :key="String(instrument.id || '')"
       :to="`/domestic-instrument/${instrument.id}`"
       :iso3="instrument.jurisdictionsAlpha3Code || ''"
@@ -35,5 +35,6 @@ const {
   error,
 } = useDomesticInstruments({
   filterCompatible,
+  limit: 9,
 });
 </script>

--- a/frontend/app/composables/useDomesticInstruments.ts
+++ b/frontend/app/composables/useDomesticInstruments.ts
@@ -1,28 +1,29 @@
-import type { Ref } from "vue";
-import { useFullTable } from "@/composables/useFullTable";
+import { computed, type Ref } from "vue";
+import { useFullTableWithFilters } from "@/composables/useFullTable";
+import type { TypedFilter } from "@/types/api";
 import type { DomesticInstrumentResponse } from "@/types/entities/domestic-instrument";
 
 export function useDomesticInstruments({
   filterCompatible,
+  limit,
 }: {
   filterCompatible: Ref<boolean>;
+  limit?: number;
 }) {
-  return useFullTable<"Domestic Instruments", DomesticInstrumentResponse>(
-    "Domestic Instruments",
-    {
-      select: (data) => {
-        // Sort by date descending
-        const sorted = data
-          .slice()
-          .sort((a, b) => Number(b.date) - Number(a.date));
-        // Filter by compatibility if enabled
-        if (filterCompatible.value) {
-          return sorted.filter(
-            (item) => item.compatibleWithTheHcchPrinciples === true,
-          );
-        }
-        return sorted;
-      },
-    },
+  const filters = computed<TypedFilter<"Domestic Instruments">[]>(() =>
+    filterCompatible.value
+      ? [{ column: "compatibleWithTheHcchPrinciples", value: true }]
+      : [],
   );
+
+  return useFullTableWithFilters<
+    "Domestic Instruments",
+    DomesticInstrumentResponse
+  >("Domestic Instruments", filters, {
+    limit,
+    orderBy: limit ? "date" : undefined,
+    orderDir: limit ? "desc" : undefined,
+    select: (data) =>
+      data.slice().sort((a, b) => Number(b.date) - Number(a.date)),
+  });
 }

--- a/frontend/app/composables/useFullTable.test.ts
+++ b/frontend/app/composables/useFullTable.test.ts
@@ -31,7 +31,7 @@ describe("useFullTable", () => {
 
     expect(useQuery).toHaveBeenCalledWith(
       expect.objectContaining({
-        queryKey: ["Questions", undefined],
+        queryKey: ["Questions", undefined, null, null, null],
       }),
     );
   });
@@ -43,7 +43,21 @@ describe("useFullTable", () => {
 
     expect(useQuery).toHaveBeenCalledWith(
       expect.objectContaining({
-        queryKey: ["Questions", "Test"],
+        queryKey: ["Questions", "Test", null, null, null],
+      }),
+    );
+  });
+
+  it("includes pagination params in query key when provided", () => {
+    useFullTable("Questions", {
+      limit: 5,
+      orderBy: "date",
+      orderDir: "desc",
+    });
+
+    expect(useQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: ["Questions", undefined, 5, "date", "desc"],
       }),
     );
   });

--- a/frontend/app/composables/useFullTable.ts
+++ b/frontend/app/composables/useFullTable.ts
@@ -18,10 +18,17 @@ import { formatYear } from "@/utils/format";
 
 type ApiClient = ReturnType<typeof createClient<paths>>;
 
+export interface FullTableQueryParams {
+  limit?: number;
+  orderBy?: string;
+  orderDir?: "asc" | "desc";
+}
+
 export async function fetchFullTableData<T extends TableName>(
   client: ApiClient,
   table: T,
   filters: TypedFilter<T>[] = [],
+  params: FullTableQueryParams = {},
 ): Promise<TableResponseMap[T][]> {
   const { data, error } = await client.POST("/search/full_table", {
     body: {
@@ -33,6 +40,9 @@ export async function fetchFullTableData<T extends TableName>(
           }))
         : null,
       response_type: null,
+      limit: params.limit ?? null,
+      order_by: params.orderBy ?? null,
+      order_dir: params.orderDir ?? null,
     },
   });
   if (error) throw error;
@@ -43,7 +53,7 @@ interface UseFullTableOptions<
   T extends TableName,
   TProcessed,
   TSelected = TProcessed[],
-> {
+> extends FullTableQueryParams {
   filters?: TypedFilter<T>[];
   process?: (raw: TableResponseMap[T]) => TProcessed;
   select?: (data: TProcessed[]) => TSelected;
@@ -56,15 +66,23 @@ export function useFullTable<
   TSelected = TProcessed[],
 >(table: T, options: UseFullTableOptions<T, TProcessed, TSelected> = {}) {
   const { client } = useApiClient();
-  const { filters, process, select, enabled } = options;
+  const { filters, process, select, enabled, limit, orderBy, orderDir } =
+    options;
 
   return useQuery({
     queryKey: [
       table,
       filters ? filters.map((f) => f.value).join(",") : undefined,
+      limit ?? null,
+      orderBy ?? null,
+      orderDir ?? null,
     ],
     queryFn: async () => {
-      const data = await fetchFullTableData(client, table, filters);
+      const data = await fetchFullTableData(client, table, filters, {
+        limit,
+        orderBy,
+        orderDir,
+      });
       if (process) {
         return data.map(process);
       }
@@ -86,15 +104,22 @@ export function useFullTableWithFilters<
   options: Omit<UseFullTableOptions<T, TProcessed, TSelected>, "filters"> = {},
 ) {
   const { client } = useApiClient();
-  const { process, select, enabled } = options;
+  const { process, select, enabled, limit, orderBy, orderDir } = options;
 
   return useQuery({
     queryKey: computed(() => [
       table,
       filters.value.map((f) => f.value).join(","),
+      limit ?? null,
+      orderBy ?? null,
+      orderDir ?? null,
     ]),
     queryFn: async () => {
-      const data = await fetchFullTableData(client, table, filters.value);
+      const data = await fetchFullTableData(client, table, filters.value, {
+        limit,
+        orderBy,
+        orderDir,
+      });
       if (process) {
         return data.map(process);
       }
@@ -122,9 +147,13 @@ export function useInternationalLegalProvisions() {
   });
 }
 
-export function useLeadingCases() {
+export function useLeadingCases(options: { limit?: number } = {}) {
+  const { limit } = options;
   return useFullTable("Court Decisions", {
     filters: [{ column: "caseRank", value: 10 }],
+    limit,
+    orderBy: limit ? "publicationDateIso" : undefined,
+    orderDir: limit ? "desc" : undefined,
     select: (data) => {
       return data.sort(
         (a, b) =>

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -33,6 +33,10 @@
                 src="https://choiceoflaw.blob.core.windows.net/assets/Prix-ORD-DEF_2025.png"
                 alt="Swiss National ORD Prize 2025"
                 class="hero-badge-img"
+                width="64"
+                height="67"
+                loading="lazy"
+                decoding="async"
               />
               <span class="hero-badge-text">Swiss National ORD Prize 2025</span>
             </a>
@@ -73,7 +77,12 @@
     </div>
 
     <div class="animate-fade-up animate-delay-1 col-span-12">
-      <JurisdictionMap />
+      <ClientOnly>
+        <JurisdictionMap />
+        <template #fallback>
+          <div class="map-ssr-placeholder" aria-hidden="true" />
+        </template>
+      </ClientOnly>
     </div>
 
     <!-- Explore Data Section -->
@@ -157,15 +166,30 @@
     </div>
 
     <div class="col-span-12 flex md:col-span-7">
-      <RecentDomesticInstruments />
+      <ClientOnly>
+        <RecentDomesticInstruments />
+        <template #fallback>
+          <div class="card-ssr-placeholder" aria-hidden="true" />
+        </template>
+      </ClientOnly>
     </div>
 
     <div class="col-span-12 flex md:col-span-5">
-      <PopularSearches />
+      <ClientOnly>
+        <PopularSearches />
+        <template #fallback>
+          <div class="card-ssr-placeholder" aria-hidden="true" />
+        </template>
+      </ClientOnly>
     </div>
 
     <div class="col-span-12 flex md:col-span-7">
-      <SuccessfulLegalTransplantations />
+      <ClientOnly>
+        <SuccessfulLegalTransplantations />
+        <template #fallback>
+          <div class="card-ssr-placeholder" aria-hidden="true" />
+        </template>
+      </ClientOnly>
     </div>
 
     <div class="col-span-12 flex md:col-span-5">
@@ -182,7 +206,12 @@
     </div>
 
     <div class="col-span-12 flex md:col-span-7">
-      <PlotCourtDecisionsJurisdiction />
+      <ClientOnly>
+        <PlotCourtDecisionsJurisdiction />
+        <template #fallback>
+          <div class="card-ssr-placeholder" aria-hidden="true" />
+        </template>
+      </ClientOnly>
     </div>
 
     <div class="col-span-12 flex md:col-span-5">
@@ -197,11 +226,21 @@
       />
     </div>
     <div class="col-span-12 flex md:col-span-7">
-      <LeadingCases />
+      <ClientOnly>
+        <LeadingCases />
+        <template #fallback>
+          <div class="card-ssr-placeholder" aria-hidden="true" />
+        </template>
+      </ClientOnly>
     </div>
 
     <div class="col-span-12 flex md:col-span-5">
-      <TopLiteratureThemes />
+      <ClientOnly>
+        <TopLiteratureThemes />
+        <template #fallback>
+          <div class="card-ssr-placeholder" aria-hidden="true" />
+        </template>
+      </ClientOnly>
     </div>
 
     <!-- Stay Connected Section -->
@@ -246,22 +285,38 @@
 </template>
 
 <script setup lang="ts">
-import PopularSearches from "@/components/landing-page/PopularSearches.vue";
-import TopLiteratureThemes from "@/components/landing-page/TopLiteratureThemes.vue";
-import JurisdictionMap from "@/components/landing-page/JurisdictionMap.vue";
+import { defineAsyncComponent } from "vue";
 import HeroJurisdictionPicker from "@/components/landing-page/HeroJurisdictionPicker.vue";
 import ConnectCard from "@/components/landing-page/ConnectCard.vue";
 import NumberCard from "@/components/landing-page/NumberCard.vue";
 import CompareJurisdictionsCard from "@/components/landing-page/CompareJurisdictionsCard.vue";
 import SectionHeader from "@/components/ui/SectionHeader.vue";
 import { externalLinks } from "@/utils/externalLinks";
-import RecentDomesticInstruments from "@/components/landing-page/RecentDomesticInstruments.vue";
-import SuccessfulLegalTransplantations from "@/components/landing-page/SuccessfulLegalTransplantations.vue";
-import LeadingCases from "@/components/landing-page/LeadingCases.vue";
 import { useHead, useRuntimeConfig, useRouter } from "#imports";
-import PlotCourtDecisionsJurisdiction from "@/components/landing-page/PlotCourtDecisionsJurisdiction.vue";
 import { useJurisdictions } from "@/composables/useJurisdictions";
 import type { JurisdictionOption } from "@/types/analyzer";
+
+const JurisdictionMap = defineAsyncComponent(
+  () => import("@/components/landing-page/JurisdictionMap.vue"),
+);
+const PopularSearches = defineAsyncComponent(
+  () => import("@/components/landing-page/PopularSearches.vue"),
+);
+const TopLiteratureThemes = defineAsyncComponent(
+  () => import("@/components/landing-page/TopLiteratureThemes.vue"),
+);
+const RecentDomesticInstruments = defineAsyncComponent(
+  () => import("@/components/landing-page/RecentDomesticInstruments.vue"),
+);
+const SuccessfulLegalTransplantations = defineAsyncComponent(
+  () => import("@/components/landing-page/SuccessfulLegalTransplantations.vue"),
+);
+const LeadingCases = defineAsyncComponent(
+  () => import("@/components/landing-page/LeadingCases.vue"),
+);
+const PlotCourtDecisionsJurisdiction = defineAsyncComponent(
+  () => import("@/components/landing-page/PlotCourtDecisionsJurisdiction.vue"),
+);
 
 const links = externalLinks;
 const config = useRuntimeConfig();
@@ -296,6 +351,26 @@ useHead({
 </script>
 
 <style scoped>
+.map-ssr-placeholder {
+  width: 100%;
+  height: 600px;
+  border-radius: 1rem;
+  background: var(--gradient-subtle);
+}
+
+@media (max-width: 640px) {
+  .map-ssr-placeholder {
+    height: 400px;
+  }
+}
+
+.card-ssr-placeholder {
+  width: 100%;
+  min-height: 320px;
+  border-radius: 0.75rem;
+  background: var(--gradient-subtle);
+}
+
 h2 {
   font-weight: 500;
 }

--- a/frontend/app/types/api-schema.d.ts
+++ b/frontend/app/types/api-schema.d.ts
@@ -1659,6 +1659,9 @@ export interface components {
      *           "value": "Switzerland"
      *         }
      *       ],
+     *       "limit": 10,
+     *       "order_by": "date",
+     *       "order_dir": "desc",
      *       "response_type": "parsed",
      *       "table": "Answers"
      *     }
@@ -1671,6 +1674,15 @@ export interface components {
        * @default parsed
        */
       response_type: "parsed" | null;
+      /** @description Maximum number of rows to return. Omit for no limit. */
+      limit?: number | null;
+      /** @description Column name to sort by (camelCase or snake_case). Unknown columns are ignored. */
+      order_by?: string | null;
+      /**
+       * @description Sort direction when order_by is provided.
+       * @default desc
+       */
+      order_dir: ("asc" | "desc") | null;
     };
     /**
      * FullTextSearchRequest

--- a/frontend/app/types/openapi.json
+++ b/frontend/app/types/openapi.json
@@ -8142,6 +8142,43 @@
             ],
             "description": "Response data format. Only 'parsed' is supported.",
             "default": "parsed"
+          },
+          "limit": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 10000.0,
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Maximum number of rows to return. Omit for no limit."
+          },
+          "order_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Column name to sort by (camelCase or snake_case). Unknown columns are ignored."
+          },
+          "order_dir": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": ["asc", "desc"]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Sort direction when order_by is provided.",
+            "default": "desc"
           }
         },
         "type": "object",
@@ -8155,6 +8192,9 @@
                 "value": "Switzerland"
               }
             ],
+            "limit": 10,
+            "order_by": "date",
+            "order_dir": "desc",
             "response_type": "parsed",
             "table": "Answers"
           }

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -8,6 +8,7 @@ export default defineNuxtConfig({
   devtools: { enabled: process.env.NODE_ENV === "development" },
   ssr: true,
   nitro: {
+    compressPublicAssets: { brotli: true, gzip: true },
     prerender: {
       crawlLinks: false,
       routes: [],


### PR DESCRIPTION
## Summary

- Add `limit` / `order_by` / `order_dir` to `/search/full_table` and thread through `SearchService.full_table` / `filtered_table`. Homepage cards now request exactly the rows they render: `LeadingCases` (6), `RecentDomesticInstruments` (3), `SuccessfulLegalTransplantations` (9, with the HCCH-compatibility filter pushed to the server instead of post-fetched).
- Wrap below-the-fold landing-page widgets in `ClientOnly` + `defineAsyncComponent` with skeleton fallbacks, preconnect to the blob CDN, enable Brotli/gzip in Nitro, and drop the redundant `pnpm install` from the runtime Docker stage (Nuxt's `.output` is self-contained).

## Test plan

- [x] `cd backend && make check` (193 passed, 2 skipped)
- [x] `cd frontend && pnpm run check` (155 passed)
- [ ] Manual: load the homepage and confirm three landing cards each return exactly limit rows and Successful Legal Transplantations only contains HCCH-compatible instruments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)