### PR TITLE
feat(api): add GET alternatives to data fetching endpoints

### DIFF
--- a/backend/app/routes/ai.py
+++ b/backend/app/routes/ai.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Depends, HTTPException
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from app.auth import verify_frontend_request
 from app.schemas.requests import ClassifyQueryRequest
@@ -12,24 +14,44 @@ def get_query_classifier() -> QueryClassifier:
 router = APIRouter(prefix="/ai", tags=["AI"], dependencies=[Depends(verify_frontend_request)])
 
 
+_CLASSIFY_QUERY_DESCRIPTION = "Uses an external model to classify the user's query into one of the predefined CoLD categories."
+_CLASSIFY_QUERY_RESPONSES: dict[int | str, dict[str, Any]] = {
+    200: {
+        "description": "Classification result",
+        "content": {"application/json": {"example": "Party autonomy (concept)"}},
+    },
+    502: {"description": "Upstream AI service error."},
+}
+
+
+def _do_classify_query(query: str, classifier: QueryClassifier) -> str:
+    classification = classifier.classify_user_query(query)
+    if isinstance(classification, dict):
+        raise HTTPException(status_code=502, detail=classification.get("error", "Upstream AI service error"))
+    return classification
+
+
 @router.post(
     "/classify_query",
     summary="Classify a free-text user query into a predefined category",
-    description=("Uses an external model to classify the user's query into one of the predefined CoLD categories."),
-    responses={
-        200: {
-            "description": "Classification result",
-            "content": {"application/json": {"example": "Party autonomy (concept)"}},
-        },
-        502: {"description": "Upstream AI service error."},
-    },
+    description=_CLASSIFY_QUERY_DESCRIPTION,
+    responses=_CLASSIFY_QUERY_RESPONSES,
 )
 def classify_query(
     body: ClassifyQueryRequest,
     classifier: QueryClassifier = Depends(get_query_classifier),
 ) -> str:
-    query = body.query
-    classification = classifier.classify_user_query(query)
-    if isinstance(classification, dict):
-        raise HTTPException(status_code=502, detail=classification.get("error", "Upstream AI service error"))
-    return classification
+    return _do_classify_query(body.query, classifier)
+
+
+@router.get(
+    "/classify_query",
+    summary="Classify a free-text user query (GET alternative)",
+    description=_CLASSIFY_QUERY_DESCRIPTION,
+    responses=_CLASSIFY_QUERY_RESPONSES,
+)
+def classify_query_get(
+    query: Annotated[str, Query(description="Free-text query to classify, e.g. 'How do courts treat party autonomy?'")],
+    classifier: QueryClassifier = Depends(get_query_classifier),
+) -> str:
+    return _do_classify_query(query, classifier)

--- a/backend/app/routes/search.py
+++ b/backend/app/routes/search.py
@@ -1,8 +1,8 @@
 import logging
 import re
-from typing import Any
+from typing import Annotated, Any, Literal
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic.alias_generators import to_camel
 
 from app.auth import verify_frontend_request
@@ -10,6 +10,9 @@ from app.schemas.details import TABLE_DETAIL_MODELS, AnyDetail, DetailBase
 from app.schemas.records import AnyRecord, validate_record
 from app.schemas.requests import (
     CuratedDetailsRequest,
+    FilterValue,
+    FTFilterOption,
+    FTSFilterOption,
     FullTableRequest,
     FullTextSearchRequest,
 )
@@ -33,6 +36,33 @@ def _camel_keys(obj: Any) -> Any:
     return obj
 
 
+def _coerce_filter_value(raw: str) -> FilterValue:
+    lowered = raw.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    if raw and re.fullmatch(r"-?\d+", raw):
+        return int(raw)
+    return raw
+
+
+def _parse_full_table_filter(raw: str) -> FTFilterOption:
+    if ":" not in raw:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid filter '{raw}': expected format 'column:value' or 'column:val1,val2'",
+        )
+    column, _, value_part = raw.partition(":")
+    column = column.strip()
+    if not column:
+        raise HTTPException(status_code=400, detail=f"Invalid filter '{raw}': column is empty")
+    parts = [v.strip() for v in value_part.split(",")] if "," in value_part else [value_part]
+    coerced = [_coerce_filter_value(v) for v in parts]
+    value: FilterValue | list[FilterValue] = coerced[0] if len(coerced) == 1 else coerced
+    return FTFilterOption(column=column, value=value)
+
+
 def get_search_service() -> SearchService:
     """Dependency function to lazily instantiate the SearchService."""
     return SearchService()
@@ -45,59 +75,14 @@ router = APIRouter(
 )
 
 
-@router.post(
-    "/",
-    summary="Full-text search across CoLD data",
-    description=(
-        "Searches across multiple domains (Answers, HCCH Answers, Court Decisions, Domestic Instruments, Regional Instruments, International Instruments, Literature, Arbitral Awards, and Arbitral Rules). "  # noqa: E501
-        "Filters support user-facing fields like 'tables', 'Jurisdictions', or 'Themes'. "
-        "You can sort by date and paginate results."
-    ),
-    responses={
-        200: {
-            "description": "Search results including pagination and total matches.",
-            "content": {
-                "application/json": {
-                    "example": {
-                        "query": "example search",
-                        "filters": [{"column": "tables", "values": ["Answers"]}],
-                        "total_matches": 2,
-                        "page": 1,
-                        "page_size": 2,
-                        "results": [
-                            {
-                                "source_table": "Answers",
-                                "id": "CHE_15-TC",
-                                "Title": "…",
-                            },
-                            {
-                                "source_table": "Court Decisions",
-                                "id": "CD-GBR-1167",
-                                "Title": "…",
-                            },
-                        ],
-                    }
-                }
-            },
-        }
-    },
-)
-def handle_full_text_search(
-    body: FullTextSearchRequest,
-    search_service: SearchService = Depends(get_search_service),
+def _do_full_text_search(
+    search_string: str | None,
+    filters: list[FTSFilterOption],
+    page: int,
+    page_size: int,
+    sort_by_date: bool,
+    search_service: SearchService,
 ) -> FullTextSearchResponse:
-    search_string = body.search_string
-    filters = body.filters or []
-    page = body.page
-    page_size = body.page_size
-    sort_by_date = body.sort_by_date or False
-    response_type = body.response_type or "parsed"
-    if response_type != "parsed":
-        raise HTTPException(
-            status_code=400,
-            detail="Only response_type='parsed' is supported for typed search results",
-        )
-
     raw = search_service.full_text_search(
         search_string,
         filters,
@@ -110,74 +95,34 @@ def handle_full_text_search(
     return FullTextSearchResponse(results=validated_results, **raw)
 
 
-@router.post(
-    "/details",
-    summary="Fetch a curated record by CoLD ID including relations",
-    description="Given a table and a CoLD ID, returns the record with all first-hop relations in a standardized shape.",
-    response_model=AnyDetail,
-    responses={404: {"description": "Record not found."}},
-)
-def handle_entity_detail(
-    body: CuratedDetailsRequest,
-    search_service: SearchService = Depends(get_search_service),
-) -> AnyDetail:
+def _do_entity_detail(table: str, cold_id: str, search_service: SearchService) -> AnyDetail:
     try:
-        result = search_service.get_entity_detail(body.table, body.id)
+        result = search_service.get_entity_detail(table, cold_id)
     except ValueError as e:
-        logger.warning("Invalid entity detail request: table=%s id=%s: %s", body.table, body.id, e)
+        logger.warning("Invalid entity detail request: table=%s id=%s: %s", table, cold_id, e)
         raise HTTPException(status_code=400, detail="Invalid request parameters") from e
     if not result:
-        raise HTTPException(status_code=404, detail=f"No record found for {body.id} in {body.table}")
+        raise HTTPException(status_code=404, detail=f"No record found for {cold_id} in {table}")
     model = TABLE_DETAIL_MODELS.get(result.get("source_table", ""), DetailBase)
     return model.model_validate(result)
 
 
-@router.post(
-    "/full_table",
-    summary="Return full or filtered table",
-    description=(
-        "Returns all records from the specified table or a filtered subset. Filters accept user-facing field names and values (mapping-aware)."  # noqa: E501
-    ),
-    responses={
-        200: {
-            "description": "Array of transformed records from the requested table.",
-            "content": {
-                "application/json": {
-                    "example": [
-                        {
-                            "source_table": "Answers",
-                            "id": "CHE_15-TC",
-                            "Jurisdictions": ["Switzerland"],
-                            "Title": "…",
-                        }
-                    ]
-                }
-            },
-        },
-        400: {"description": "Missing or invalid table parameter."},
-        500: {"description": "Server error while querying the table."},
-    },
-)
-def return_full_table(
-    body: FullTableRequest,
-    search_service: SearchService = Depends(get_search_service),
+def _do_full_table(
+    table: str,
+    filters: list[FTFilterOption],
+    order_by: str | None,
+    order_dir: str | None,
+    limit: int | None,
+    search_service: SearchService,
 ) -> list[AnyRecord]:
-    table = body.table
-    filters = body.filters or []
-    response_type = getattr(body, "response_type", "parsed")
-    order_by = body.order_by
-    order_dir = body.order_dir
-    limit = body.limit
-
     if not table:
         raise HTTPException(status_code=400, detail="No table provided")
-
     try:
         if filters:
             results = search_service.filtered_table(
                 table,
                 filters,
-                response_type=response_type,
+                response_type="parsed",
                 order_by=order_by,
                 order_dir=order_dir,
                 limit=limit,
@@ -185,7 +130,7 @@ def return_full_table(
         else:
             results = search_service.full_table(
                 table,
-                response_type=response_type,
+                response_type="parsed",
                 order_by=order_by,
                 order_dir=order_dir,
                 limit=limit,
@@ -195,6 +140,219 @@ def return_full_table(
         raise HTTPException(status_code=500, detail="Failed to query table") from e
 
     return [validate_record(_camel_keys(r)) for r in results]
+
+
+_FULL_TEXT_SEARCH_RESPONSES: dict[int | str, dict[str, Any]] = {
+    200: {
+        "description": "Search results including pagination and total matches.",
+        "content": {
+            "application/json": {
+                "example": {
+                    "query": "example search",
+                    "filters": [{"column": "tables", "values": ["Answers"]}],
+                    "total_matches": 2,
+                    "page": 1,
+                    "page_size": 2,
+                    "results": [
+                        {
+                            "source_table": "Answers",
+                            "id": "CHE_15-TC",
+                            "Title": "…",
+                        },
+                        {
+                            "source_table": "Court Decisions",
+                            "id": "CD-GBR-1167",
+                            "Title": "…",
+                        },
+                    ],
+                }
+            }
+        },
+    }
+}
+
+_FULL_TEXT_SEARCH_DESCRIPTION = (
+    "Searches across multiple domains (Answers, HCCH Answers, Court Decisions, Domestic Instruments, "
+    "Regional Instruments, International Instruments, Literature, Arbitral Awards, and Arbitral Rules). "
+    "Filters support user-facing fields like 'tables', 'Jurisdictions', or 'Themes'. "
+    "You can sort by date and paginate results."
+)
+
+
+@router.post(
+    "/",
+    summary="Full-text search across CoLD data",
+    description=_FULL_TEXT_SEARCH_DESCRIPTION,
+    responses=_FULL_TEXT_SEARCH_RESPONSES,
+)
+def handle_full_text_search(
+    body: FullTextSearchRequest,
+    search_service: SearchService = Depends(get_search_service),
+) -> FullTextSearchResponse:
+    response_type = body.response_type or "parsed"
+    if response_type != "parsed":
+        raise HTTPException(
+            status_code=400,
+            detail="Only response_type='parsed' is supported for typed search results",
+        )
+    return _do_full_text_search(
+        body.search_string,
+        body.filters or [],
+        body.page,
+        body.page_size,
+        body.sort_by_date or False,
+        search_service,
+    )
+
+
+@router.get(
+    "/",
+    summary="Full-text search across CoLD data (GET alternative)",
+    description=(
+        f"{_FULL_TEXT_SEARCH_DESCRIPTION}\n\n"
+        "Filter columns are exposed as dedicated repeatable query parameters: "
+        "`tables`, `jurisdictions`, `themes`. Pass each value separately, e.g. "
+        "`?tables=Answers&tables=Court%20Decisions&jurisdictions=Switzerland`."
+    ),
+    responses=_FULL_TEXT_SEARCH_RESPONSES,
+)
+def handle_full_text_search_get(
+    search_string: Annotated[str | None, Query(description="Free-text query string")] = None,
+    tables: Annotated[list[str] | None, Query(description="Restrict to source tables (repeatable)")] = None,
+    jurisdictions: Annotated[list[str] | None, Query(description="Filter by jurisdictions (repeatable)")] = None,
+    themes: Annotated[list[str] | None, Query(description="Filter by themes (repeatable)")] = None,
+    page: Annotated[int, Query(ge=1, description="Page number, must be >= 1")] = 1,
+    page_size: Annotated[int, Query(ge=1, le=100, description="Number of results per page")] = 50,
+    sort_by_date: Annotated[bool, Query(description="Sort results by date descending if True.")] = False,
+    search_service: SearchService = Depends(get_search_service),
+) -> FullTextSearchResponse:
+    filters: list[FTSFilterOption] = []
+    if tables:
+        filters.append(FTSFilterOption(column="tables", values=tables))
+    if jurisdictions:
+        filters.append(FTSFilterOption(column="jurisdictions", values=jurisdictions))
+    if themes:
+        filters.append(FTSFilterOption(column="themes", values=themes))
+    return _do_full_text_search(search_string, filters, page, page_size, sort_by_date, search_service)
+
+
+_ENTITY_DETAIL_RESPONSES: dict[int | str, dict[str, Any]] = {404: {"description": "Record not found."}}
+_ENTITY_DETAIL_DESCRIPTION = (
+    "Given a table and a CoLD ID, returns the record with all first-hop relations in a standardized shape."
+)
+
+
+@router.post(
+    "/details",
+    summary="Fetch a curated record by CoLD ID including relations",
+    description=_ENTITY_DETAIL_DESCRIPTION,
+    response_model=AnyDetail,
+    responses=_ENTITY_DETAIL_RESPONSES,
+)
+def handle_entity_detail(
+    body: CuratedDetailsRequest,
+    search_service: SearchService = Depends(get_search_service),
+) -> AnyDetail:
+    return _do_entity_detail(body.table, body.id, search_service)
+
+
+@router.get(
+    "/details",
+    summary="Fetch a curated record by CoLD ID (GET alternative)",
+    description=_ENTITY_DETAIL_DESCRIPTION,
+    response_model=AnyDetail,
+    responses=_ENTITY_DETAIL_RESPONSES,
+)
+def handle_entity_detail_get(
+    table: Annotated[str, Query(description="Source table name (e.g. 'Answers')")],
+    cold_id: Annotated[str, Query(alias="id", description="CoLD ID for the record")],
+    search_service: SearchService = Depends(get_search_service),
+) -> AnyDetail:
+    return _do_entity_detail(table, cold_id, search_service)
+
+
+_FULL_TABLE_RESPONSES: dict[int | str, dict[str, Any]] = {
+    200: {
+        "description": "Array of transformed records from the requested table.",
+        "content": {
+            "application/json": {
+                "example": [
+                    {
+                        "source_table": "Answers",
+                        "id": "CHE_15-TC",
+                        "Jurisdictions": ["Switzerland"],
+                        "Title": "…",
+                    }
+                ]
+            }
+        },
+    },
+    400: {"description": "Missing or invalid table parameter."},
+    500: {"description": "Server error while querying the table."},
+}
+_FULL_TABLE_DESCRIPTION = (
+    "Returns all records from the specified table or a filtered subset. "
+    "Filters accept user-facing field names and values (mapping-aware)."
+)
+
+
+@router.post(
+    "/full_table",
+    summary="Return full or filtered table",
+    description=_FULL_TABLE_DESCRIPTION,
+    responses=_FULL_TABLE_RESPONSES,
+)
+def return_full_table(
+    body: FullTableRequest,
+    search_service: SearchService = Depends(get_search_service),
+) -> list[AnyRecord]:
+    return _do_full_table(
+        body.table,
+        body.filters or [],
+        body.order_by,
+        body.order_dir,
+        body.limit,
+        search_service,
+    )
+
+
+@router.get(
+    "/full_table",
+    summary="Return full or filtered table (GET alternative)",
+    description=(
+        f"{_FULL_TABLE_DESCRIPTION}\n\n"
+        "Filters use the repeatable `filter` query parameter with format `column:value` "
+        "or `column:val1,val2` for multiple values. Values matching `true`/`false` are "
+        "parsed as booleans; pure-digit strings as integers; everything else stays a string. "
+        "Example: `?table=Court%20Decisions&filter=caseRank:10&filter=jurisdiction:Switzerland`."
+    ),
+    responses=_FULL_TABLE_RESPONSES,
+)
+def return_full_table_get(
+    table: Annotated[str, Query(description="Source table name")],
+    filter_: Annotated[
+        list[str] | None,
+        Query(
+            alias="filter",
+            description="Filter as 'column:value' or 'column:val1,val2'. Repeatable.",
+        ),
+    ] = None,
+    limit: Annotated[
+        int | None,
+        Query(ge=1, le=10000, description="Maximum number of rows to return. Omit for no limit."),
+    ] = None,
+    order_by: Annotated[
+        str | None,
+        Query(description="Column name to sort by (camelCase or snake_case). Unknown columns are ignored."),
+    ] = None,
+    order_dir: Annotated[
+        Literal["asc", "desc"] | None,
+        Query(description="Sort direction when order_by is provided."),
+    ] = "desc",
+    search_service: SearchService = Depends(get_search_service),
+) -> list[AnyRecord]:
+    filters = [_parse_full_table_filter(f) for f in (filter_ or [])]
+    return _do_full_table(table, filters, order_by, order_dir, limit, search_service)
 
 
 @router.get(

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -1,5 +1,7 @@
 import pytest
+from fastapi import HTTPException
 
+from app.routes.search import _coerce_filter_value, _parse_full_table_filter
 from app.schemas.details import TABLE_DETAIL_MODELS
 from app.schemas.entities import EntityBase
 from app.schemas.records import TABLE_RECORD_MODELS
@@ -149,3 +151,67 @@ class TestFullTextSearchResponseSerialization:
         dumped = response.model_dump(by_alias=True)
         assert dumped["results"] == []
         assert dumped["totalMatches"] == 0
+
+
+class TestCoerceFilterValue:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("true", True),
+            ("True", True),
+            ("false", False),
+            ("False", False),
+            ("0", 0),
+            ("10", 10),
+            ("-3", -3),
+            ("Switzerland", "Switzerland"),
+            ("12abc", "12abc"),
+            ("", ""),
+            ("Party autonomy", "Party autonomy"),
+        ],
+    )
+    def test_coerces_expected(self, raw: str, expected):
+        result = _coerce_filter_value(raw)
+        assert result == expected
+        assert type(result) is type(expected)
+
+
+class TestParseFullTableFilter:
+    def test_single_string_value(self):
+        f = _parse_full_table_filter("jurisdiction:Switzerland")
+        assert f.column == "jurisdiction"
+        assert f.value == "Switzerland"
+
+    def test_single_int_value(self):
+        f = _parse_full_table_filter("caseRank:10")
+        assert f.column == "caseRank"
+        assert f.value == 10
+
+    def test_single_bool_value(self):
+        f = _parse_full_table_filter("isPublic:true")
+        assert f.column == "isPublic"
+        assert f.value is True
+
+    def test_csv_values_become_list(self):
+        f = _parse_full_table_filter("jurisdiction:Switzerland,France,Germany")
+        assert f.column == "jurisdiction"
+        assert f.value == ["Switzerland", "France", "Germany"]
+
+    def test_csv_values_with_mixed_types(self):
+        f = _parse_full_table_filter("flag:true,false")
+        assert f.value == [True, False]
+
+    def test_value_with_colon_keeps_remainder(self):
+        f = _parse_full_table_filter("title:Smith v. Jones: A Case")
+        assert f.column == "title"
+        assert f.value == "Smith v. Jones: A Case"
+
+    def test_missing_colon_raises(self):
+        with pytest.raises(HTTPException) as exc:
+            _parse_full_table_filter("invalid")
+        assert exc.value.status_code == 400
+
+    def test_empty_column_raises(self):
+        with pytest.raises(HTTPException) as exc:
+            _parse_full_table_filter(":value")
+        assert exc.value.status_code == 400

--- a/frontend/app/composables/useApiClient.test.ts
+++ b/frontend/app/composables/useApiClient.test.ts
@@ -33,19 +33,20 @@ describe("useApiClient", () => {
     );
 
     const { client } = useApiClient();
-    await client.POST("/search/", {
-      body: {
-        search_string: "test",
-        page: 1,
-        page_size: 10,
-        sort_by_date: false,
-        response_type: null,
+    await client.GET("/search/", {
+      params: {
+        query: {
+          search_string: "test",
+          page: 1,
+          page_size: 10,
+          sort_by_date: false,
+        },
       },
     });
 
     expect(fetch).toHaveBeenCalledOnce();
     const request = vi.mocked(fetch).mock.calls[0]![0] as Request;
     expect(request.url).toContain("/api/proxy/search/");
-    expect(request.method).toBe("POST");
+    expect(request.method).toBe("GET");
   });
 });

--- a/frontend/app/composables/useEntityData.ts
+++ b/frontend/app/composables/useEntityData.ts
@@ -62,8 +62,8 @@ export function useEntityData(
       const cfg = config.value;
       const table = resolvedTable.value;
       if (!cfg || !table) return null;
-      const { data, error } = await client.POST("/search/details", {
-        body: { table, id: toValue(coldId) },
+      const { data, error } = await client.GET("/search/details", {
+        params: { query: { table, id: toValue(coldId) } },
       });
       if (error) {
         const detail = (error as { detail?: unknown }).detail;

--- a/frontend/app/composables/useFullTable.test.ts
+++ b/frontend/app/composables/useFullTable.test.ts
@@ -13,7 +13,7 @@ vi.mock("@tanstack/vue-query", () => ({
 vi.mock("./useApiClient", () => ({
   useApiClient: vi.fn(() => ({
     client: {
-      POST: vi.fn().mockResolvedValue({ data: [], error: null }),
+      GET: vi.fn().mockResolvedValue({ data: [], error: null }),
     },
   })),
 }));
@@ -43,9 +43,27 @@ describe("useFullTable", () => {
 
     expect(useQuery).toHaveBeenCalledWith(
       expect.objectContaining({
-        queryKey: ["Questions", "Test", null, null, null],
+        queryKey: ["Questions", JSON.stringify(filters), null, null, null],
       }),
     );
+  });
+
+  it("disambiguates filter sets that previously collided on join", () => {
+    const singleCsvValue = [{ column: "question" as const, value: "a,b" }];
+    const twoSeparateValues = [
+      { column: "question" as const, value: "a" },
+      { column: "question" as const, value: "b" },
+    ];
+
+    useFullTable("Questions", { filters: singleCsvValue });
+    const [firstArg] = vi.mocked(useQuery).mock.calls.at(-1)!;
+    const firstKey = (firstArg as { queryKey: unknown }).queryKey;
+
+    useFullTable("Questions", { filters: twoSeparateValues });
+    const [secondArg] = vi.mocked(useQuery).mock.calls.at(-1)!;
+    const secondKey = (secondArg as { queryKey: unknown }).queryKey;
+
+    expect(firstKey).not.toEqual(secondKey);
   });
 
   it("includes pagination params in query key when provided", () => {

--- a/frontend/app/composables/useFullTable.ts
+++ b/frontend/app/composables/useFullTable.ts
@@ -24,25 +24,33 @@ export interface FullTableQueryParams {
   orderDir?: "asc" | "desc";
 }
 
+const encodeFilter = <T extends TableName>(filter: TypedFilter<T>): string => {
+  const serialized = String(filter.value);
+  if (serialized.includes(",")) {
+    throw new Error(
+      `Filter value for column "${String(filter.column)}" contains a comma; ` +
+        "the GET /search/full_table wire format reserves ',' as a multi-value separator. " +
+        "Use the POST endpoint for values containing commas.",
+    );
+  }
+  return `${String(filter.column)}:${serialized}`;
+};
+
 export async function fetchFullTableData<T extends TableName>(
   client: ApiClient,
   table: T,
   filters: TypedFilter<T>[] = [],
   params: FullTableQueryParams = {},
 ): Promise<TableResponseMap[T][]> {
-  const { data, error } = await client.POST("/search/full_table", {
-    body: {
-      table,
-      filters: filters.length
-        ? filters.map((f) => ({
-            column: String(f.column),
-            value: f.value,
-          }))
-        : null,
-      response_type: null,
-      limit: params.limit ?? null,
-      order_by: params.orderBy ?? null,
-      order_dir: params.orderDir ?? null,
+  const { data, error } = await client.GET("/search/full_table", {
+    params: {
+      query: {
+        table,
+        filter: filters.length ? filters.map(encodeFilter) : undefined,
+        limit: params.limit ?? undefined,
+        order_by: params.orderBy ?? undefined,
+        order_dir: params.orderDir ?? undefined,
+      },
     },
   });
   if (error) throw error;
@@ -72,7 +80,7 @@ export function useFullTable<
   return useQuery({
     queryKey: [
       table,
-      filters ? filters.map((f) => f.value).join(",") : undefined,
+      filters ? JSON.stringify(filters) : undefined,
       limit ?? null,
       orderBy ?? null,
       orderDir ?? null,
@@ -109,7 +117,7 @@ export function useFullTableWithFilters<
   return useQuery({
     queryKey: computed(() => [
       table,
-      filters.value.map((f) => f.value).join(","),
+      JSON.stringify(filters.value),
       limit ?? null,
       orderBy ?? null,
       orderDir ?? null,

--- a/frontend/app/composables/useNumberCount.ts
+++ b/frontend/app/composables/useNumberCount.ts
@@ -10,19 +10,15 @@ const fetchNumberCount = async (tableName: TableName) => {
 
   const { client } = useApiClient();
 
-  const { data, error } = await client.POST("/search/", {
-    body: {
-      search_string: "",
-      filters: [
-        {
-          column: "tables",
-          values: [tableName],
-        },
-      ],
-      page: 1,
-      page_size: 1,
-      sort_by_date: false,
-      response_type: null,
+  const { data, error } = await client.GET("/search/", {
+    params: {
+      query: {
+        search_string: "",
+        tables: [tableName],
+        page: 1,
+        page_size: 1,
+        sort_by_date: false,
+      },
     },
   });
 

--- a/frontend/app/composables/useRecordDetails.ts
+++ b/frontend/app/composables/useRecordDetails.ts
@@ -17,8 +17,8 @@ async function fetchRecordDetails<
   id: string | number,
   process?: (raw: TableDetailMap[T]) => TProcessed,
 ) {
-  const { data, error } = await client.POST("/search/details", {
-    body: { table, id: String(id) },
+  const { data, error } = await client.GET("/search/details", {
+    params: { query: { table, id: String(id) } },
   });
   if (error) throw error;
   const raw = data as unknown as TableDetailMap[T];
@@ -55,8 +55,8 @@ export function useAnswer(id: Ref<string | number>) {
   return useQuery({
     queryKey: computed(() => [table.value, id.value]),
     queryFn: async () => {
-      const { data, error } = await client.POST("/search/details", {
-        body: { table: table.value, id: String(id.value) },
+      const { data, error } = await client.GET("/search/details", {
+        params: { query: { table: table.value, id: String(id.value) } },
       });
       if (error) throw error;
       return processQuestion(data as Parameters<typeof processQuestion>[0]);

--- a/frontend/app/composables/useSearch.ts
+++ b/frontend/app/composables/useSearch.ts
@@ -5,55 +5,40 @@ import { useApiClient } from "@/composables/useApiClient";
 import type { SearchParams, SearchResponse } from "@/types/api";
 import type { paths } from "@/types/api-schema";
 
+const TYPE_FILTER_MAPPING: Record<string, string> = {
+  Questions: "Answers",
+  "Court Decisions": "Court Decisions",
+  "Legal Instruments": "Domestic Instruments",
+  "Domestic Instruments": "Domestic Instruments",
+  "Regional Instruments": "Regional Instruments",
+  "International Instruments": "International Instruments",
+  Literature: "Literature",
+  "Arbitral Awards": "Arbitral Awards",
+  "Arbitral Rules": "Arbitral Rules",
+};
+
+const splitCsv = (value: string | undefined): string[] | undefined =>
+  value ? value.split(",").filter(Boolean) : undefined;
+
 const fetchSearchResults = async (
   client: ReturnType<typeof createClient<paths>>,
   { query, filters, page = 1, pageSize = 10 }: SearchParams,
 ): Promise<SearchResponse> => {
-  const searchFilters: { column: string; values: string[] }[] = [];
+  const types = splitCsv(filters.type)?.map(
+    (type) => TYPE_FILTER_MAPPING[type] || type,
+  );
 
-  if (filters.jurisdiction) {
-    searchFilters.push({
-      column: "jurisdictions",
-      values: filters.jurisdiction.split(","),
-    });
-  }
-
-  if (filters.theme) {
-    searchFilters.push({
-      column: "themes",
-      values: filters.theme.split(","),
-    });
-  }
-
-  const typeFilterMapping: Record<string, string> = {
-    Questions: "Answers",
-    "Court Decisions": "Court Decisions",
-    "Legal Instruments": "Domestic Instruments",
-    "Domestic Instruments": "Domestic Instruments",
-    "Regional Instruments": "Regional Instruments",
-    "International Instruments": "International Instruments",
-    Literature: "Literature",
-    "Arbitral Awards": "Arbitral Awards",
-    "Arbitral Rules": "Arbitral Rules",
-  };
-
-  if (filters.type) {
-    searchFilters.push({
-      column: "tables",
-      values: filters.type
-        .split(",")
-        .map((type) => typeFilterMapping[type] || type),
-    });
-  }
-
-  const { data, error } = await client.POST("/search/", {
-    body: {
-      search_string: query || "",
-      page,
-      page_size: pageSize,
-      filters: searchFilters,
-      sort_by_date: filters.sortBy === "date",
-      response_type: null,
+  const { data, error } = await client.GET("/search/", {
+    params: {
+      query: {
+        search_string: query || "",
+        page,
+        page_size: pageSize,
+        sort_by_date: filters.sortBy === "date",
+        jurisdictions: splitCsv(filters.jurisdiction),
+        themes: splitCsv(filters.theme),
+        tables: types,
+      },
     },
   });
 

--- a/frontend/app/types/api-schema.d.ts
+++ b/frontend/app/types/api-schema.d.ts
@@ -11,7 +11,13 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    get?: never;
+    /**
+     * Full-text search across CoLD data (GET alternative)
+     * @description Searches across multiple domains (Answers, HCCH Answers, Court Decisions, Domestic Instruments, Regional Instruments, International Instruments, Literature, Arbitral Awards, and Arbitral Rules). Filters support user-facing fields like 'tables', 'Jurisdictions', or 'Themes'. You can sort by date and paginate results.
+     *
+     *     Filter columns are exposed as dedicated repeatable query parameters: `tables`, `jurisdictions`, `themes`. Pass each value separately, e.g. `?tables=Answers&tables=Court%20Decisions&jurisdictions=Switzerland`.
+     */
+    get: operations["handle_full_text_search_get_api_v1_search__get"];
     put?: never;
     /**
      * Full-text search across CoLD data
@@ -31,7 +37,11 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    get?: never;
+    /**
+     * Fetch a curated record by CoLD ID (GET alternative)
+     * @description Given a table and a CoLD ID, returns the record with all first-hop relations in a standardized shape.
+     */
+    get: operations["handle_entity_detail_get_api_v1_search_details_get"];
     put?: never;
     /**
      * Fetch a curated record by CoLD ID including relations
@@ -51,7 +61,13 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    get?: never;
+    /**
+     * Return full or filtered table (GET alternative)
+     * @description Returns all records from the specified table or a filtered subset. Filters accept user-facing field names and values (mapping-aware).
+     *
+     *     Filters use the repeatable `filter` query parameter with format `column:value` or `column:val1,val2` for multiple values. Values matching `true`/`false` are parsed as booleans; pure-digit strings as integers; everything else stays a string. Example: `?table=Court%20Decisions&filter=caseRank:10&filter=jurisdiction:Switzerland`.
+     */
+    get: operations["return_full_table_get_api_v1_search_full_table_get"];
     put?: never;
     /**
      * Return full or filtered table
@@ -91,7 +107,11 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    get?: never;
+    /**
+     * Classify a free-text user query (GET alternative)
+     * @description Uses an external model to classify the user's query into one of the predefined CoLD categories.
+     */
+    get: operations["classify_query_get_api_v1_ai_classify_query_get"];
     put?: never;
     /**
      * Classify a free-text user query into a predefined category
@@ -2893,6 +2913,80 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+  handle_full_text_search_get_api_v1_search__get: {
+    parameters: {
+      query?: {
+        /** @description Free-text query string */
+        search_string?: string | null;
+        /** @description Restrict to source tables (repeatable) */
+        tables?: string[] | null;
+        /** @description Filter by jurisdictions (repeatable) */
+        jurisdictions?: string[] | null;
+        /** @description Filter by themes (repeatable) */
+        themes?: string[] | null;
+        /** @description Page number, must be >= 1 */
+        page?: number;
+        /** @description Number of results per page */
+        page_size?: number;
+        /** @description Sort results by date descending if True. */
+        sort_by_date?: boolean;
+      };
+      header?: {
+        "X-API-Key"?: string;
+      };
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Search results including pagination and total matches. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+           * @example {
+           *       "query": "example search",
+           *       "filters": [
+           *         {
+           *           "column": "tables",
+           *           "values": [
+           *             "Answers"
+           *           ]
+           *         }
+           *       ],
+           *       "total_matches": 2,
+           *       "page": 1,
+           *       "page_size": 2,
+           *       "results": [
+           *         {
+           *           "source_table": "Answers",
+           *           "id": "CHE_15-TC",
+           *           "Title": "…"
+           *         },
+           *         {
+           *           "source_table": "Court Decisions",
+           *           "id": "CD-GBR-1167",
+           *           "Title": "…"
+           *         }
+           *       ]
+           *     }
+           */
+          "application/json": components["schemas"]["FullTextSearchResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
   handle_full_text_search_api_v1_search__post: {
     parameters: {
       query?: never;
@@ -2944,6 +3038,67 @@ export interface operations {
            */
           "application/json": components["schemas"]["FullTextSearchResponse"];
         };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  handle_entity_detail_get_api_v1_search_details_get: {
+    parameters: {
+      query: {
+        /** @description Source table name (e.g. 'Answers') */
+        table: string;
+        /** @description CoLD ID for the record */
+        id: string;
+      };
+      header?: {
+        "X-API-Key"?: string;
+      };
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json":
+            | components["schemas"]["AnswerDetail"]
+            | components["schemas"]["HcchAnswerDetail"]
+            | components["schemas"]["QuestionDetail"]
+            | components["schemas"]["JurisdictionDetail"]
+            | components["schemas"]["CourtDecisionDetail"]
+            | components["schemas"]["DomesticInstrumentDetail"]
+            | components["schemas"]["DomesticLegalProvisionDetail"]
+            | components["schemas"]["RegionalInstrumentDetail"]
+            | components["schemas"]["RegionalLegalProvisionDetail"]
+            | components["schemas"]["InternationalInstrumentDetail"]
+            | components["schemas"]["InternationalLegalProvisionDetail"]
+            | components["schemas"]["LiteratureDetail"]
+            | components["schemas"]["ArbitralAwardDetail"]
+            | components["schemas"]["ArbitralInstitutionDetail"]
+            | components["schemas"]["ArbitralRuleDetail"]
+            | components["schemas"]["ArbitralProvisionDetail"]
+            | components["schemas"]["SpecialistDetail"]
+            | components["schemas"]["DetailBase"];
+        };
+      };
+      /** @description Record not found. */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
       };
       /** @description Validation Error */
       422: {
@@ -3013,6 +3168,92 @@ export interface operations {
         content: {
           "application/json": components["schemas"]["HTTPValidationError"];
         };
+      };
+    };
+  };
+  return_full_table_get_api_v1_search_full_table_get: {
+    parameters: {
+      query: {
+        /** @description Source table name */
+        table: string;
+        /** @description Filter as 'column:value' or 'column:val1,val2'. Repeatable. */
+        filter?: string[] | null;
+        /** @description Maximum number of rows to return. Omit for no limit. */
+        limit?: number | null;
+        /** @description Column name to sort by (camelCase or snake_case). Unknown columns are ignored. */
+        order_by?: string | null;
+        /** @description Sort direction when order_by is provided. */
+        order_dir?: ("asc" | "desc") | null;
+      };
+      header?: {
+        "X-API-Key"?: string;
+      };
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Array of transformed records from the requested table. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+           * @example [
+           *       {
+           *         "source_table": "Answers",
+           *         "id": "CHE_15-TC",
+           *         "Jurisdictions": [
+           *           "Switzerland"
+           *         ],
+           *         "Title": "…"
+           *       }
+           *     ]
+           */
+          "application/json": (
+            | components["schemas"]["AnswerRecord"]
+            | components["schemas"]["CourtDecisionRecord"]
+            | components["schemas"]["DomesticInstrumentRecord"]
+            | components["schemas"]["InternationalInstrumentRecord"]
+            | components["schemas"]["RegionalInstrumentRecord"]
+            | components["schemas"]["LiteratureRecord"]
+            | components["schemas"]["ArbitralAwardRecord"]
+            | components["schemas"]["ArbitralInstitutionRecord"]
+            | components["schemas"]["ArbitralProvisionRecord"]
+            | components["schemas"]["ArbitralRuleRecord"]
+            | components["schemas"]["DomesticLegalProvisionRecord"]
+            | components["schemas"]["InternationalLegalProvisionRecord"]
+            | components["schemas"]["RegionalLegalProvisionRecord"]
+            | components["schemas"]["JurisdictionRecord"]
+            | components["schemas"]["QuestionRecord"]
+            | components["schemas"]["SpecialistRecord"]
+            | components["schemas"]["RecordBase"]
+          )[];
+        };
+      };
+      /** @description Missing or invalid table parameter. */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Server error while querying the table. */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
       };
     };
   };
@@ -3151,6 +3392,48 @@ export interface operations {
       };
       /** @description Server error while querying specialists. */
       500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  classify_query_get_api_v1_ai_classify_query_get: {
+    parameters: {
+      query: {
+        /** @description Free-text query to classify, e.g. 'How do courts treat party autonomy?' */
+        query: string;
+      };
+      header?: {
+        "X-API-Key"?: string;
+      };
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Classification result */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /** @example Party autonomy (concept) */
+          "application/json": string;
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Upstream AI service error. */
+      502: {
         headers: {
           [name: string]: unknown;
         };

--- a/frontend/app/types/openapi.json
+++ b/frontend/app/types/openapi.json
@@ -87,6 +87,189 @@
             }
           }
         }
+      },
+      "get": {
+        "tags": ["Search"],
+        "summary": "Full-text search across CoLD data (GET alternative)",
+        "description": "Searches across multiple domains (Answers, HCCH Answers, Court Decisions, Domestic Instruments, Regional Instruments, International Instruments, Literature, Arbitral Awards, and Arbitral Rules). Filters support user-facing fields like 'tables', 'Jurisdictions', or 'Themes'. You can sort by date and paginate results.\n\nFilter columns are exposed as dedicated repeatable query parameters: `tables`, `jurisdictions`, `themes`. Pass each value separately, e.g. `?tables=Answers&tables=Court%20Decisions&jurisdictions=Switzerland`.",
+        "operationId": "handle_full_text_search_get_api_v1_search__get",
+        "parameters": [
+          {
+            "name": "search_string",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Free-text query string",
+              "title": "Search String"
+            },
+            "description": "Free-text query string"
+          },
+          {
+            "name": "tables",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Restrict to source tables (repeatable)",
+              "title": "Tables"
+            },
+            "description": "Restrict to source tables (repeatable)"
+          },
+          {
+            "name": "jurisdictions",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by jurisdictions (repeatable)",
+              "title": "Jurisdictions"
+            },
+            "description": "Filter by jurisdictions (repeatable)"
+          },
+          {
+            "name": "themes",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by themes (repeatable)",
+              "title": "Themes"
+            },
+            "description": "Filter by themes (repeatable)"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Page number, must be >= 1",
+              "default": 1,
+              "title": "Page"
+            },
+            "description": "Page number, must be >= 1"
+          },
+          {
+            "name": "page_size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "description": "Number of results per page",
+              "default": 50,
+              "title": "Page Size"
+            },
+            "description": "Number of results per page"
+          },
+          {
+            "name": "sort_by_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Sort results by date descending if True.",
+              "default": false,
+              "title": "Sort By Date"
+            },
+            "description": "Sort results by date descending if True."
+          },
+          {
+            "name": "X-API-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Search results including pagination and total matches.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FullTextSearchResponse"
+                },
+                "example": {
+                  "query": "example search",
+                  "filters": [
+                    {
+                      "column": "tables",
+                      "values": ["Answers"]
+                    }
+                  ],
+                  "total_matches": 2,
+                  "page": 1,
+                  "page_size": 2,
+                  "results": [
+                    {
+                      "source_table": "Answers",
+                      "id": "CHE_15-TC",
+                      "Title": "\u2026"
+                    },
+                    {
+                      "source_table": "Court Decisions",
+                      "id": "CD-GBR-1167",
+                      "Title": "\u2026"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/search/details": {
@@ -197,6 +380,126 @@
             }
           }
         }
+      },
+      "get": {
+        "tags": ["Search"],
+        "summary": "Fetch a curated record by CoLD ID (GET alternative)",
+        "description": "Given a table and a CoLD ID, returns the record with all first-hop relations in a standardized shape.",
+        "operationId": "handle_entity_detail_get_api_v1_search_details_get",
+        "parameters": [
+          {
+            "name": "table",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Source table name (e.g. 'Answers')",
+              "title": "Table"
+            },
+            "description": "Source table name (e.g. 'Answers')"
+          },
+          {
+            "name": "id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "CoLD ID for the record",
+              "title": "Id"
+            },
+            "description": "CoLD ID for the record"
+          },
+          {
+            "name": "X-API-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/AnswerDetail"
+                    },
+                    {
+                      "$ref": "#/components/schemas/HcchAnswerDetail"
+                    },
+                    {
+                      "$ref": "#/components/schemas/QuestionDetail"
+                    },
+                    {
+                      "$ref": "#/components/schemas/JurisdictionDetail"
+                    },
+                    {
+                      "$ref": "#/components/schemas/CourtDecisionDetail"
+                    },
+                    {
+                      "$ref": "#/components/schemas/DomesticInstrumentDetail"
+                    },
+                    {
+                      "$ref": "#/components/schemas/DomesticLegalProvisionDetail"
+                    },
+                    {
+                      "$ref": "#/components/schemas/RegionalInstrumentDetail"
+                    },
+                    {
+                      "$ref": "#/components/schemas/RegionalLegalProvisionDetail"
+                    },
+                    {
+                      "$ref": "#/components/schemas/InternationalInstrumentDetail"
+                    },
+                    {
+                      "$ref": "#/components/schemas/InternationalLegalProvisionDetail"
+                    },
+                    {
+                      "$ref": "#/components/schemas/LiteratureDetail"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ArbitralAwardDetail"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ArbitralInstitutionDetail"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ArbitralRuleDetail"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ArbitralProvisionDetail"
+                    },
+                    {
+                      "$ref": "#/components/schemas/SpecialistDetail"
+                    },
+                    {
+                      "$ref": "#/components/schemas/DetailBase"
+                    }
+                  ],
+                  "title": "Response Handle Entity Detail Get Api V1 Search Details Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Record not found."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/search/full_table": {
@@ -289,6 +592,205 @@
                     ]
                   },
                   "title": "Response Return Full Table Api V1 Search Full Table Post"
+                },
+                "example": [
+                  {
+                    "source_table": "Answers",
+                    "id": "CHE_15-TC",
+                    "Jurisdictions": ["Switzerland"],
+                    "Title": "\u2026"
+                  }
+                ]
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid table parameter."
+          },
+          "500": {
+            "description": "Server error while querying the table."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["Search"],
+        "summary": "Return full or filtered table (GET alternative)",
+        "description": "Returns all records from the specified table or a filtered subset. Filters accept user-facing field names and values (mapping-aware).\n\nFilters use the repeatable `filter` query parameter with format `column:value` or `column:val1,val2` for multiple values. Values matching `true`/`false` are parsed as booleans; pure-digit strings as integers; everything else stays a string. Example: `?table=Court%20Decisions&filter=caseRank:10&filter=jurisdiction:Switzerland`.",
+        "operationId": "return_full_table_get_api_v1_search_full_table_get",
+        "parameters": [
+          {
+            "name": "table",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Source table name",
+              "title": "Table"
+            },
+            "description": "Source table name"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter as 'column:value' or 'column:val1,val2'. Repeatable.",
+              "title": "Filter"
+            },
+            "description": "Filter as 'column:value' or 'column:val1,val2'. Repeatable."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "maximum": 10000,
+                  "minimum": 1
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Maximum number of rows to return. Omit for no limit.",
+              "title": "Limit"
+            },
+            "description": "Maximum number of rows to return. Omit for no limit."
+          },
+          {
+            "name": "order_by",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Column name to sort by (camelCase or snake_case). Unknown columns are ignored.",
+              "title": "Order By"
+            },
+            "description": "Column name to sort by (camelCase or snake_case). Unknown columns are ignored."
+          },
+          {
+            "name": "order_dir",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": ["asc", "desc"],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Sort direction when order_by is provided.",
+              "default": "desc",
+              "title": "Order Dir"
+            },
+            "description": "Sort direction when order_by is provided."
+          },
+          {
+            "name": "X-API-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Array of transformed records from the requested table.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/AnswerRecord"
+                      },
+                      {
+                        "$ref": "#/components/schemas/CourtDecisionRecord"
+                      },
+                      {
+                        "$ref": "#/components/schemas/DomesticInstrumentRecord"
+                      },
+                      {
+                        "$ref": "#/components/schemas/InternationalInstrumentRecord"
+                      },
+                      {
+                        "$ref": "#/components/schemas/RegionalInstrumentRecord"
+                      },
+                      {
+                        "$ref": "#/components/schemas/LiteratureRecord"
+                      },
+                      {
+                        "$ref": "#/components/schemas/ArbitralAwardRecord"
+                      },
+                      {
+                        "$ref": "#/components/schemas/ArbitralInstitutionRecord"
+                      },
+                      {
+                        "$ref": "#/components/schemas/ArbitralProvisionRecord"
+                      },
+                      {
+                        "$ref": "#/components/schemas/ArbitralRuleRecord"
+                      },
+                      {
+                        "$ref": "#/components/schemas/DomesticLegalProvisionRecord"
+                      },
+                      {
+                        "$ref": "#/components/schemas/InternationalLegalProvisionRecord"
+                      },
+                      {
+                        "$ref": "#/components/schemas/RegionalLegalProvisionRecord"
+                      },
+                      {
+                        "$ref": "#/components/schemas/JurisdictionRecord"
+                      },
+                      {
+                        "$ref": "#/components/schemas/QuestionRecord"
+                      },
+                      {
+                        "$ref": "#/components/schemas/SpecialistRecord"
+                      },
+                      {
+                        "$ref": "#/components/schemas/RecordBase"
+                      }
+                    ]
+                  },
+                  "title": "Response Return Full Table Get Api V1 Search Full Table Get"
                 },
                 "example": [
                   {
@@ -429,6 +931,61 @@
                 "schema": {
                   "type": "string",
                   "title": "Response Classify Query Api V1 Ai Classify Query Post"
+                },
+                "example": "Party autonomy (concept)"
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream AI service error."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["AI"],
+        "summary": "Classify a free-text user query (GET alternative)",
+        "description": "Uses an external model to classify the user's query into one of the predefined CoLD categories.",
+        "operationId": "classify_query_get_api_v1_ai_classify_query_get",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Free-text query to classify, e.g. 'How do courts treat party autonomy?'",
+              "title": "Query"
+            },
+            "description": "Free-text query to classify, e.g. 'How do courts treat party autonomy?'"
+          },
+          {
+            "name": "X-API-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Classification result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "title": "Response Classify Query Get Api V1 Ai Classify Query Get"
                 },
                 "example": "Party autonomy (concept)"
               }


### PR DESCRIPTION
## Summary

- Adds GET variants for `/search/`, `/search/details`, `/search/full_table`, and `/ai/classify_query`; existing POST handlers stay for backwards compatibility and now share logic via private `_do_*` helpers.
- Full-text search exposes filter columns as repeatable query params (`tables`, `jurisdictions`, `themes`); `/search/full_table` accepts a repeatable `filter=column:value` (CSV → list, with `true`/`false` and pure-digit values auto-coerced to bool/int so wire types match the POST body's `FilterValue`).
- Frontend composables (`useSearch`, `useNumberCount`, `useRecordDetails`/`useAnswer`, `useEntityData`, `useFullTable`) switched to `client.GET(...)`; regenerated `api-schema.d.ts` / `openapi.json` so openapi-fetch knows both verbs.
- `useFullTable` query keys now `JSON.stringify(filters)` instead of `.map(f => f.value).join(",")`, eliminating a cache collision between e.g. `[{value: "a,b"}]` and `[{value:"a"},{value:"b"}]`; `encodeFilter` throws if a value contains `,` since the wire format reserves it.

## Test plan

- [x] `cd backend && make check` (212 passed, 2 skipped)
- [x] `cd frontend && pnpm run check` (156 tests pass; +1 cache-disambiguation test)
- [ ] Smoke search, entity detail, full-table loads (homepage, leading cases, jurisdiction literature) in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)