### PR TITLE
refactor(frontend): route assets through assets.cold.global CDN

### DIFF
--- a/frontend/app/app.vue
+++ b/frontend/app/app.vue
@@ -9,13 +9,12 @@ useSeoMeta({
   description: "Choice of Law Dataverse",
   ogTitle: "Choice of Law Dataverse",
   ogDescription: "Navigate private international law issues with precision",
-  ogImage: "https://choiceoflaw.blob.core.windows.net/assets/cold_og_image.svg",
+  ogImage: "https://assets.cold.global/assets/cold_og_image.svg",
   ogUrl: "www.cold.global",
   twitterTitle: "Choice of Law Dataverse",
   twitterDescription:
     "Navigate private international law issues with precision",
-  twitterImage:
-    "https://choiceoflaw.blob.core.windows.net/assets/cold_og_image.svg",
+  twitterImage: "https://assets.cold.global/assets/cold_og_image.svg",
   twitterCard: "summary",
 });
 
@@ -26,7 +25,7 @@ useHead({
   link: [
     {
       rel: "preconnect",
-      href: "https://choiceoflaw.blob.core.windows.net",
+      href: "https://assets.cold.global",
       crossorigin: "",
     },
     {

--- a/frontend/app/components/layout/Footer.vue
+++ b/frontend/app/components/layout/Footer.vue
@@ -16,7 +16,7 @@ const user = useUser();
         <!-- Left: Flag + Title -->
         <div class="flex items-center gap-4">
           <img
-            src="https://choiceoflaw.blob.core.windows.net/assets/cold_flag_footer.svg"
+            src="https://assets.cold.global/assets/cold_flag_footer.svg"
             class="h-12 w-auto sm:h-14"
             alt="Choice of Law Dataverse flag"
           />

--- a/frontend/app/components/layout/Nav.vue
+++ b/frontend/app/components/layout/Nav.vue
@@ -23,7 +23,7 @@
           class="desktop-logo"
         >
           <img
-            src="https://choiceoflaw.blob.core.windows.net/assets/cold_logo.svg"
+            src="https://assets.cold.global/assets/cold_logo.svg"
             alt="CoLD Logo"
             class="logo-img h-12 w-auto"
           />
@@ -35,7 +35,7 @@
           aria-label="Home"
         >
           <img
-            src="https://choiceoflaw.blob.core.windows.net/assets/cold_logo.svg"
+            src="https://assets.cold.global/assets/cold_logo.svg"
             alt="CoLD Logo"
             class="h-8 w-auto"
           />

--- a/frontend/app/components/sources/SourceExternalLink.vue
+++ b/frontend/app/components/sources/SourceExternalLink.vue
@@ -14,7 +14,7 @@
       <template v-if="openAccess" #leading>
         <img
           class="mr-2 h-4 w-4 shrink-0 object-contain opacity-100 transition-[width,margin,opacity] duration-200 group-hover:mr-0 group-hover:w-0 group-hover:opacity-0"
-          src="https://choiceoflaw.blob.core.windows.net/assets/Open_Access_logo_PLoS_transparent.svg"
+          src="https://assets.cold.global/assets/Open_Access_logo_PLoS_transparent.svg"
           alt="Open Access Logo"
         />
       </template>

--- a/frontend/app/config/assets.ts
+++ b/frontend/app/config/assets.ts
@@ -1,5 +1,4 @@
-export const BLOB_STORAGE_BASE_URL =
-  "https://choiceoflaw.blob.core.windows.net";
+export const BLOB_STORAGE_BASE_URL = "https://assets.cold.global";
 
 export const ASSET_BASE_URL = `${BLOB_STORAGE_BASE_URL}/assets`;
 

--- a/frontend/app/config/entityRegistry.ts
+++ b/frontend/app/config/entityRegistry.ts
@@ -328,7 +328,7 @@ export const entityRegistry: Record<string, EntityConfig> = {
           key: "title",
           inlineImage: {
             dataKey: "openAccess",
-            src: "https://choiceoflaw.blob.core.windows.net/assets/Open_Access_logo_PLoS_transparent.svg",
+            src: "https://assets.cold.global/assets/Open_Access_logo_PLoS_transparent.svg",
             alt: "Open Access Logo",
             class: "ml-1 inline-flex w-3",
           },

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -30,7 +30,7 @@
               class="hero-badge"
             >
               <img
-                src="https://choiceoflaw.blob.core.windows.net/assets/Prix-ORD-DEF_2025.png"
+                src="https://assets.cold.global/assets/Prix-ORD-DEF_2025.png"
                 alt="Swiss National ORD Prize 2025"
                 class="hero-badge-img"
                 width="64"
@@ -198,7 +198,7 @@
         subtitle="Authoritative Instrument on Choice of Law"
         button-text="HCCH Principles"
         button-link="/international-instrument/II-Pri-1"
-        image-src="https://choiceoflaw.blob.core.windows.net/assets/hcch-logo-circle.svg"
+        image-src="https://assets.cold.global/assets/hcch-logo-circle.svg"
         :new-tab="false"
         :center-title="false"
         :show-top-border="true"

--- a/frontend/content/about_cold.md
+++ b/frontend/content/about_cold.md
@@ -12,7 +12,7 @@ Our main objective is to transform data points into knowledge through collaborat
 
 **CoLD is Open Research**  
 The Dataverse promotes sharing, preserving, citing, exploring and analyzing research data on choice of law. CoLD is licensed under <a href="https://creativecommons.org/licenses/by/4.0/?ref=chooser-v1" target="_blank">CC BY 4.0<img
-    src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
+    src="https://assets.cold.global/assets/external_link.svg"
     alt="external link"
     class="external-link-icon"
   /></a>.
@@ -27,21 +27,21 @@ The discipline in which this research project is inserted is private internation
 
 Follow the development of this website on GitHub:  
 <a href="https://github.com/Choice-of-Law-Dataverse/cold-web-app" target="_blank">github.com/Choice-of-Law-Dataverse/cold-web-app<img
-    src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
+    src="https://assets.cold.global/assets/external_link.svg"
     alt="external link"
     class="external-link-icon"
   /></a>
 
 ## CoLD Wins Swiss National ORD Prize 2025
 
-<img src="https://choiceoflaw.blob.core.windows.net/assets/Prix-ORD-DEF_2025.png" alt="Swiss National ORD Prize 2025" style="width:120px;float:right;margin-left:1em;" />
+<img src="https://assets.cold.global/assets/Prix-ORD-DEF_2025.png" alt="Swiss National ORD Prize 2025" style="width:120px;float:right;margin-left:1em;" />
 
 In 2025, the Choice of Law Dataverse (CoLD) project was awarded the prestigious Swiss National Prize for Open Research Data (ORD Prize) in the legal sciences category by the Swiss Academies of Arts and Sciences. This recognition highlights CoLD's innovative approach to making private international law data openly accessible and its commitment to transparent, collaborative research. The award celebrates exemplary practices in open research data and acknowledges the impact of CoLD in advancing access to legal knowledge for students, researchers, and practitioners worldwide. [Read more](https://ord.swiss-academies.ch/news/swiss-national-ord-prize-2025-for-legal-and-environmental-sciences).
 
 ## CoLD Tech Wiki
 
 For more information on the technologies used and developed to build CoLD, see <a href="https://choice-of-law-dataverse.github.io/" target="_blank">choice-of-law-dataverse.github.io<img
-    src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
+    src="https://assets.cold.global/assets/external_link.svg"
     alt="external link"
     class="external-link-icon"
   /></a>.

--- a/frontend/content/contact.md
+++ b/frontend/content/contact.md
@@ -10,11 +10,11 @@ Just send us an email: mail@cold.global
 ## Stay Updated
 
 Follow CoLD on <a href="https://www.linkedin.com/company/choice-of-law-dataverse" target="_blank">LinkedIn<img
-     src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
+     src="https://assets.cold.global/assets/external_link.svg"
      alt="external link"
      class="external-link-icon"
    /></a> and subscribe to the newsletter on <a href="https://choiceoflawdataverse.substack.com/subscribe" target="_blank">Substack<img
-     src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
+     src="https://assets.cold.global/assets/external_link.svg"
      alt="external link"
      class="external-link-icon"
    /></a>.

--- a/frontend/content/data_sets.md
+++ b/frontend/content/data_sets.md
@@ -4,6 +4,6 @@ title: Data Sets — CoLD
 
 ## Download Indexes
 
-- All court decisions ([CSV](https://choiceoflaw.blob.core.windows.net/full-tables/court-decisions.csv) | [XLSX](https://choiceoflaw.blob.core.windows.net/full-tables/court-decisions.xlsx))
-- All legislations ([CSV](https://choiceoflaw.blob.core.windows.net/full-tables/legislations.csv) | [XLSX](https://choiceoflaw.blob.core.windows.net/full-tables/legislations.xlsx))
-- All literature entries ([CSV](https://choiceoflaw.blob.core.windows.net/full-tables/literature.csv) | [XLSX](https://choiceoflaw.blob.core.windows.net/full-tables/literature.xlsx))
+- All court decisions ([CSV](https://assets.cold.global/full-tables/court-decisions.csv) | [XLSX](https://assets.cold.global/full-tables/court-decisions.xlsx))
+- All legislations ([CSV](https://assets.cold.global/full-tables/legislations.csv) | [XLSX](https://assets.cold.global/full-tables/legislations.xlsx))
+- All literature entries ([CSV](https://assets.cold.global/full-tables/literature.csv) | [XLSX](https://assets.cold.global/full-tables/literature.xlsx))

--- a/frontend/content/disclaimer.md
+++ b/frontend/content/disclaimer.md
@@ -12,7 +12,7 @@ The data published on this website is made available under the terms of the Crea
 
 For details of the CC BY-SA license, see:
 <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">https://creativecommons.org/licenses/by-sa/4.0/<img
-     src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
+     src="https://assets.cold.global/assets/external_link.svg"
      alt="external link"
      class="external-link-icon"
    /></a>

--- a/frontend/content/endorsements.md
+++ b/frontend/content/endorsements.md
@@ -2,47 +2,47 @@
 title: Endorsements — CoLD
 ---
 
-<img src="https://choiceoflaw.blob.core.windows.net/assets/hcch-logo.svg" alt="HCCH logo" style="width: 80px"/>
+<img src="https://assets.cold.global/assets/hcch-logo.svg" alt="HCCH logo" style="width: 80px"/>
 
 <a href="https://www.hcch.net/en/home" target="_blank">**The Hague Conference on Private International Law**<img
-    src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
+    src="https://assets.cold.global/assets/external_link.svg"
     alt="external link"
     class="external-link-icon"
   /></a>  
 We count on the support of the Hague Conference on Private International Law (HCCH) and its wide network of specialists. This project will also follow the future work of the HCCH on the law applicable to international commercial contracts.
 <br><br><br>
 
-<img src="https://choiceoflaw.blob.core.windows.net/assets/university-of-johannesburg-logo.svg" alt="University of Johannesburg logo" style="width: 100px"/>
+<img src="https://assets.cold.global/assets/university-of-johannesburg-logo.svg" alt="University of Johannesburg logo" style="width: 100px"/>
 
 <a href="https://www.uj.ac.za/faculties/law/research-centre-for-private-international-law-in-emerging-countries/" target="_blank">**The Research Centre for Private International Law in Emerging Countries**<img
-    src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
+    src="https://assets.cold.global/assets/external_link.svg"
     alt="external link"
     class="external-link-icon"
   /></a>  
 Led by Prof Jan L Neels and Prof Eesa A Fredericks (Project Partners), the Research Centre for Private International Law in Emerging Countries at the University of Johannesburg develops studies on the harmonization of international commercial law, most notably the African Principles on the Law Applicable to International Commercial Contracts.  
 <br><br><br>
-<img src="https://choiceoflaw.blob.core.windows.net/assets/universite-de-montreal-logo.svg" alt="Université de Montréal logo" style="width: 150px"/>
+<img src="https://assets.cold.global/assets/universite-de-montreal-logo.svg" alt="Université de Montréal logo" style="width: 150px"/>
 
 <a href="https://www.umontreal.ca/" target="_blank">**Université de Montréal**<img
-    src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
+    src="https://assets.cold.global/assets/external_link.svg"
     alt="external link"
     class="external-link-icon"
   /></a>  
 Prof Geneviève Saumier is the dean of the Faculty of Law of the Université de Montréal and also serves as a Project Partner for the Dataverse. She has worked closely with the HCCH and has developed numerous studies on private international law.
 <br><br><br>
-<img src="https://choiceoflaw.blob.core.windows.net/assets/cedep-logo.svg" alt="CEDEP logo" style="width: 120px"/>
+<img src="https://assets.cold.global/assets/cedep-logo.svg" alt="CEDEP logo" style="width: 120px"/>
 
 <a href="https://e-cedep.cedep.org.py/" target="_blank">**CEDEP**<img
-    src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
+    src="https://assets.cold.global/assets/external_link.svg"
     alt="external link"
     class="external-link-icon"
   /></a>  
 CEDEP is a research institute with global outreach that promotes courses and events closely related to the studies developed by this project.
 <br><br><br>
-<img src="https://choiceoflaw.blob.core.windows.net/assets/universitaet-luzern-logo.svg" alt="Universität Luzern logo" style="width: 170px"/>
+<img src="https://assets.cold.global/assets/universitaet-luzern-logo.svg" alt="Universität Luzern logo" style="width: 170px"/>
 
 <a href="https://www.unilu.ch/en/study/study-programmes/masters-degrees/faculty-of-humanities-and-social-sciences/lucerne-master-in-computational-social-sciences-lumacss/" target="_blank">**The Lucerne Master in Computational Social Sciences**<img
-    src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
+    src="https://assets.cold.global/assets/external_link.svg"
     alt="external link"
     class="external-link-icon"
   /></a>  

--- a/frontend/content/faq.md
+++ b/frontend/content/faq.md
@@ -7,7 +7,7 @@ title: FAQ — CoLD
 <iframe width="560" height="315" src="https://www.youtube.com/embed/1RtRCGOVJDk?si=lMmnUeOj5i_vgW64" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 Read the full text of the <a href="https://www.hcch.net/en/instruments/conventions/full-text/?cid=135" target="_blank">HCCH Principles<img
-    src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
+    src="https://assets.cold.global/assets/external_link.svg"
     alt="external link"
     class="external-link-icon"
   /></a>.

--- a/frontend/content/methodology_questionnaire_intro.md
+++ b/frontend/content/methodology_questionnaire_intro.md
@@ -3,7 +3,7 @@
 Besides displaying the relevant information on legal provisions and case law decisions, the main dataset on choice of law contains an analytical layer. The work is organized around a questionnaire designed to systematize standard answers about choice of law rules in various jurisdictions. It covers the following topics:
 
 - **Codification of private international law**: The first set of questions revolves around whether rules of private international law are codified and if there is any ongoing revision. Based on the response, further questions explore the role of the <a href="https://www.hcch.net/en/instruments/conventions/specialised-sections/choice-of-law-principles" target="_blank">HCCH Principles<img
-     src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
+     src="https://assets.cold.global/assets/external_link.svg"
      alt="external link"
      class="external-link-icon"
    /></a> in this context.

--- a/frontend/content/open_educational_resources.md
+++ b/frontend/content/open_educational_resources.md
@@ -5,12 +5,12 @@ title: Open Educational Resources — CoLD
 ## ‌Choice of Law in International Commercial Contracts
 
 This <a href="https://global.oup.com/academic/product/choice-of-law-in-international-commercial-contracts-9780198840107?cc=ch&lang=en" target="_blank">book<img
-    src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
+    src="https://assets.cold.global/assets/external_link.svg"
     alt="external link"
     class="external-link-icon"
   /></a> is the main output of the previous research project, “Hague Principles and Beyond”. It contains over sixty reports dealing with the regulation of choice of law in a significant number of jurisdictions around the world and a general report. The book has been applauded by the academic community, and it is regarded as a definitive reference guide to the key choice of law principles on international contracts.
 <a href="https://fdslive.oup.com/www.oup.com/academic/pdf/13/9780198840107_chapter1.pdf" target="_blank">Read the General Comparative Report<img
-    src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
+    src="https://assets.cold.global/assets/external_link.svg"
     alt="external link"
     class="external-link-icon"
   /></a>.
@@ -18,7 +18,7 @@ This <a href="https://global.oup.com/academic/product/choice-of-law-in-internati
 ## ‌Uniform Law Review
 
 Volume 22, Issue 2, June 2017 - special issue on the HCCH Principles (<a href="https://academic.oup.com/ulr/issue/22/2" target="_blank">available through paywall<img
-    src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
+    src="https://assets.cold.global/assets/external_link.svg"
     alt="external link"
     class="external-link-icon"
   /></a>)
@@ -27,7 +27,7 @@ Volume 22, Issue 2, June 2017 - special issue on the HCCH Principles (<a href="h
 
 Official materials from the Hague Conference on Private International Law
 Consult the <a href="https://www.hcch.net/en/instruments/conventions/specialised-sections/choice-of-law-principles" target="_blank">HCCH page<img
-    src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
+    src="https://assets.cold.global/assets/external_link.svg"
     alt="external link"
     class="external-link-icon"
   /></a>, regularly updated.
@@ -75,7 +75,7 @@ Consult the <a href="https://www.hcch.net/en/instruments/conventions/specialised
 - Michael Douglas and Nicholas Loadsmant, [‘The Impact of the Hague Principles on Choice of Law in International Commercial Contracts’ (2018)](/literature/L-81) 19 Melbourne Journal of International Law 1.
 
 <a href="/search?type=Literature">See all texts and references<img
-    src="https://choiceoflaw.blob.core.windows.net/assets/arrow_forward.svg"
+    src="https://assets.cold.global/assets/arrow_forward.svg"
     class="external-link-icon"
   /></a>
 

--- a/frontend/content/press.md
+++ b/frontend/content/press.md
@@ -7,7 +7,7 @@ title: Press — CoLD
 November 23, 2023
 
 The online platform "Choice of Law Dataverse", which is being developed as part of a research project at the Faculty of Law, aims to simplify work in the field of Private International Law in the future. Project coordinator Agatha Brandão de Oliveira explains… <a href="https://www.unilu.ch/en/news/open-science-im-internationalen-privatrecht-8079/" target="_blank">Read more<img
-    src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
+    src="https://assets.cold.global/assets/external_link.svg"
     alt="external link"
     class="external-link-icon"
   /></a>
@@ -19,7 +19,7 @@ The online platform "Choice of Law Dataverse", which is being developed as part 
 June 7, 2023
 
 Mit einer neuen online-Plattform sollen Daten des internationalen Privatrechts digital zugänglich gemacht werden. Ein entsprechendes Projekt an der Rechtswissenschaftlichen Fakultät der Universität Luzern wird vom Schweizerischen Nationalfonds (SNF) mit 845'000 Franken gefördert. <a href="https://www.unilu.ch/news/online-plattform-fuer-internationales-privatrecht-7653/" target="_blank">Read more<img
-    src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
+    src="https://assets.cold.global/assets/external_link.svg"
     alt="external link"
     class="external-link-icon"
   /></a>
@@ -31,7 +31,7 @@ Mit einer neuen online-Plattform sollen Daten des internationalen Privatrechts d
 June 7, 2023
 
 Research on preserving biodiversity, emotional eating or the use of digital learning media: the SNSF has once again awarded project funding grants. 337 projects will receive a total of 242 million francs. <a href="https://www.snf.ch/en/ckAW2GIICmVebi46/news/project-funding-242-million-francs-for-research-on-self-chosen-topics" target="_blank">Read more<img
-    src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
+    src="https://assets.cold.global/assets/external_link.svg"
     alt="external link"
     class="external-link-icon"
   /></a>

--- a/frontend/content/supporters.md
+++ b/frontend/content/supporters.md
@@ -4,7 +4,7 @@ title: Supporters — CoLD
 
 ## Who Supports CoLD?
 
-<div><img src="https://choiceoflaw.blob.core.windows.net/assets/snf-logo.svg" alt="Swiss National Science Foundation logo" style="width: 250px; margin-bottom: 0.5rem"/></div>
+<div><img src="https://assets.cold.global/assets/snf-logo.svg" alt="Swiss National Science Foundation logo" style="width: 250px; margin-bottom: 0.5rem"/></div>
 
 - Swiss National Science Foundation: “The Hague Principles and Beyond”, Project No. 179515 (2018–2021)
 - Forschungskommission der Universität Luzern: Start up funding (2022)

--- a/frontend/content/team.md
+++ b/frontend/content/team.md
@@ -9,7 +9,7 @@ title: Team — CoLD
 **Daniel Girsberger** Project Leader
 
 <a href="https://www.unilu.ch/en/faculties/faculty-of-law/professorships/girsberger-daniel/" target="_blank">Daniel<img
-    src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
+    src="https://assets.cold.global/assets/external_link.svg"
     alt="external link"
     class="external-link-icon"
   /></a> is the grant holder of the SNF Project. He oversees the strategic and operational decisions and is responsible for data quality control for the Dataverse. Daniel steers the Scientific Board, composed of legal experts from all continents.
@@ -19,7 +19,7 @@ title: Team — CoLD
 **Agatha Brandão de Oliveira** Project Coordinator
 
 <a href="https://www.unilu.ch/en/faculties/faculty-of-law/professorships/girsberger-daniel/staff/agatha-brandao-de-oliveira-mlaw" target="_blank">Agatha<img
-    src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
+    src="https://assets.cold.global/assets/external_link.svg"
     alt="external link"
     class="external-link-icon"
   /></a> is responsible for the strategic vision and practical execution of the project. She manages a multidisciplinary staff and is in charge of fostering partnerships. Agatha also acts as a Senior Researcher for the Dataverse, with a focus on data input.
@@ -29,7 +29,7 @@ title: Team — CoLD
 **Rorick Daniel Tovar Galván** Senior Researcher
 
 <a href="https://www.unilu.ch/en/faculties/faculty-of-law/professorships/girsberger-daniel/staff/dr-rorick-daniel-tovar-galvan-llm/" target="_blank">Rorick<img
-    src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
+    src="https://assets.cold.global/assets/external_link.svg"
     alt="external link"
     class="external-link-icon"
   /></a> holds a Ph.D. from the University of Bern, Switzerland. He oversees data input from Latin American countries into the Dataverse.
@@ -39,7 +39,7 @@ title: Team — CoLD
 **Anna Ptitsina** Editorial Assistant
 
 <a href="https://www.unilu.ch/en/faculties/faculty-of-law/professorships/girsberger-daniel/staff/anna-ptitsina/#tab=c163381" target="_blank">Anna<img
-    src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
+    src="https://assets.cold.global/assets/external_link.svg"
     alt="external link"
     class="external-link-icon"
   /></a> is in charge of integrating the Dataverse information into academic publications.
@@ -49,7 +49,7 @@ title: Team — CoLD
 **Dominic McMahon** Legal NLP Specialist & Data Analytics Lead
 
 <a href="https://www.unilu.ch/fakultaeten/rf/professuren/girsberger-daniel/mitarbeitende/dominic-mcmahon-mlaw/" target="_blank">Dominic<img
-    src="https://choiceoflaw.blob.core.windows.net/assets/external_link.svg"
+    src="https://assets.cold.global/assets/external_link.svg"
     alt="external link"
     class="external-link-icon"
   /></a> has recently completed his Master's degree in Law at the University of Lucerne. He acts as a Researcher for the Dataverse, with a focus on data analysis and data input. Dominic is also responsible for administrative tasks and event coordination.


### PR DESCRIPTION
## Summary
- Replace all `choiceoflaw.blob.core.windows.net` references in the frontend with `assets.cold.global`, the Cloudflare-fronted CDN hostname for static blob assets (flags, logos, OG images, external-link icons, full-tables CSV/XLSX downloads).
- `BLOB_STORAGE_BASE_URL` in `frontend/app/config/assets.ts` is the single source of truth; markdown content files are updated inline since they can't import constants.
- A Cloudflare Worker bound to `assets.cold.global` proxies requests to the blob origin and rewrites `Cache-Control: public, max-age=31536000, immutable` on every response, giving us edge caching and ~zero blob-origin hits without touching any blob HTTP headers.

## Test plan
- [x] `pnpm run check` (format, lint, typecheck, 155 vitest tests) passes
- [x] `curl -I https://assets.cold.global/assets/flags/che.svg` returns `200` with the immutable `Cache-Control` header
- [ ] Smoke-check landing page, jurisdiction picker, and content pages render flags, logos, and external-link icons after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)