### PR TITLE
fix(frontend): wrap footer auth link in ClientOnly to avoid hydration mismatch

### DIFF
--- a/frontend/app/components/layout/Footer.vue
+++ b/frontend/app/components/layout/Footer.vue
@@ -81,17 +81,24 @@ const user = useUser();
         >
           <h3 class="footer-heading my-2">Admin</h3>
           <div class="flex flex-col gap-3 text-right md:text-left">
-            <a
-              v-if="user"
-              href="/auth/logout"
-              class="footer-link cursor-pointer"
-            >
-              Logout
-            </a>
+            <ClientOnly>
+              <a
+                v-if="user"
+                href="/auth/logout"
+                class="footer-link cursor-pointer"
+              >
+                Logout
+              </a>
+              <a v-else href="/auth/login" class="footer-link cursor-pointer">
+                Login
+              </a>
 
-            <a v-else href="/auth/login" class="footer-link cursor-pointer">
-              Login
-            </a>
+              <template #fallback>
+                <a href="/auth/login" class="footer-link cursor-pointer">
+                  Login
+                </a>
+              </template>
+            </ClientOnly>
 
             <NuxtLink to="/moderation" class="footer-link">
               Moderation


### PR DESCRIPTION
## Summary
- Wrap the user-dependent footer auth link (Login/Logout) in `<ClientOnly>` with a Login fallback so the SSR-rendered markup matches the initial client render and avoids a hydration mismatch.

## Test plan
- [ ] Load any page logged out — footer shows Login, no hydration warning in console.
- [ ] Load any page logged in — footer shows Logout after hydration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)