### PR TITLE
refactor(api): unblock Cloudflare edge caching for public reads

### DIFF
--- a/backend/app/routes/landing_page.py
+++ b/backend/app/routes/landing_page.py
@@ -1,6 +1,5 @@
 from fastapi import APIRouter, Depends
 
-from app.auth import verify_frontend_request
 from app.schemas.responses import LandingPageJurisdiction
 from app.services.landing_page import LandingPageService
 
@@ -10,8 +9,7 @@ def get_landing_page_service() -> LandingPageService:
     return LandingPageService()
 
 
-# Define router
-router = APIRouter(prefix="/landing-page", tags=["LandingPage"], dependencies=[Depends(verify_frontend_request)])
+router = APIRouter(prefix="/landing-page", tags=["LandingPage"])
 
 
 @router.get(

--- a/backend/app/routes/search.py
+++ b/backend/app/routes/search.py
@@ -71,7 +71,6 @@ def get_search_service() -> SearchService:
 router = APIRouter(
     prefix="/search",
     tags=["Search"],
-    dependencies=[Depends(verify_frontend_request)],
 )
 
 
@@ -184,6 +183,7 @@ _FULL_TEXT_SEARCH_DESCRIPTION = (
     summary="Full-text search across CoLD data",
     description=_FULL_TEXT_SEARCH_DESCRIPTION,
     responses=_FULL_TEXT_SEARCH_RESPONSES,
+    dependencies=[Depends(verify_frontend_request)],
 )
 def handle_full_text_search(
     body: FullTextSearchRequest,
@@ -248,6 +248,7 @@ _ENTITY_DETAIL_DESCRIPTION = (
     description=_ENTITY_DETAIL_DESCRIPTION,
     response_model=AnyDetail,
     responses=_ENTITY_DETAIL_RESPONSES,
+    dependencies=[Depends(verify_frontend_request)],
 )
 def handle_entity_detail(
     body: CuratedDetailsRequest,
@@ -301,6 +302,7 @@ _FULL_TABLE_DESCRIPTION = (
     summary="Return full or filtered table",
     description=_FULL_TABLE_DESCRIPTION,
     responses=_FULL_TABLE_RESPONSES,
+    dependencies=[Depends(verify_frontend_request)],
 )
 def return_full_table(
     body: FullTableRequest,

--- a/backend/app/routes/sitemap.py
+++ b/backend/app/routes/sitemap.py
@@ -1,6 +1,5 @@
 from fastapi import APIRouter, Depends
 
-from app.auth import verify_frontend_request
 from app.schemas.responses import SitemapEntry
 from app.services.sitemap import SitemapService
 
@@ -10,7 +9,7 @@ def get_sitemap_service() -> SitemapService:
     return SitemapService()
 
 
-router = APIRouter(prefix="/sitemap", tags=["Sitemap"], dependencies=[Depends(verify_frontend_request)])
+router = APIRouter(prefix="/sitemap", tags=["Sitemap"])
 
 
 @router.get("/urls")

--- a/backend/app/routes/statistics.py
+++ b/backend/app/routes/statistics.py
@@ -1,6 +1,5 @@
 from fastapi import APIRouter, Depends, Query
 
-from app.auth import verify_frontend_request
 from app.schemas.responses import JurisdictionCount, JurisdictionCoverage
 from app.services.statistics import StatisticsService
 
@@ -10,8 +9,7 @@ def get_statistics_service() -> StatisticsService:
     return StatisticsService()
 
 
-# Define router
-router = APIRouter(prefix="/statistics", tags=["Statistics"], dependencies=[Depends(verify_frontend_request)])
+router = APIRouter(prefix="/statistics", tags=["Statistics"])
 
 
 @router.get(

--- a/frontend/app/components/layout/Footer.vue
+++ b/frontend/app/components/layout/Footer.vue
@@ -81,17 +81,24 @@ const user = useUser();
         >
           <h3 class="footer-heading my-2">Admin</h3>
           <div class="flex flex-col gap-3 text-right md:text-left">
-            <a
-              v-if="user"
-              href="/auth/logout"
-              class="footer-link cursor-pointer"
-            >
-              Logout
-            </a>
+            <ClientOnly>
+              <a
+                v-if="user"
+                href="/auth/logout"
+                class="footer-link cursor-pointer"
+              >
+                Logout
+              </a>
+              <a v-else href="/auth/login" class="footer-link cursor-pointer">
+                Login
+              </a>
 
-            <a v-else href="/auth/login" class="footer-link cursor-pointer">
-              Login
-            </a>
+              <template #fallback>
+                <a href="/auth/login" class="footer-link cursor-pointer">
+                  Login
+                </a>
+              </template>
+            </ClientOnly>
 
             <NuxtLink to="/moderation" class="footer-link">
               Moderation

--- a/frontend/app/types/api-schema.d.ts
+++ b/frontend/app/types/api-schema.d.ts
@@ -2931,9 +2931,7 @@ export interface operations {
         /** @description Sort results by date descending if True. */
         sort_by_date?: boolean;
       };
-      header?: {
-        "X-API-Key"?: string;
-      };
+      header?: never;
       path?: never;
       cookie?: never;
     };
@@ -3058,9 +3056,7 @@ export interface operations {
         /** @description CoLD ID for the record */
         id: string;
       };
-      header?: {
-        "X-API-Key"?: string;
-      };
+      header?: never;
       path?: never;
       cookie?: never;
     };
@@ -3185,9 +3181,7 @@ export interface operations {
         /** @description Sort direction when order_by is provided. */
         order_dir?: ("asc" | "desc") | null;
       };
-      header?: {
-        "X-API-Key"?: string;
-      };
+      header?: never;
       path?: never;
       cookie?: never;
     };
@@ -3339,9 +3333,7 @@ export interface operations {
   get_specialists_by_jurisdiction_api_v1_search_specialists__jurisdiction_alpha_code__get: {
     parameters: {
       query?: never;
-      header?: {
-        "X-API-Key"?: string;
-      };
+      header?: never;
       path: {
         jurisdiction_alpha_code: string;
       };
@@ -3681,9 +3673,7 @@ export interface operations {
   get_all_frontend_urls_api_v1_sitemap_urls_get: {
     parameters: {
       query?: never;
-      header?: {
-        "X-API-Key"?: string;
-      };
+      header?: never;
       path?: never;
       cookie?: never;
     };
@@ -3698,23 +3688,12 @@ export interface operations {
           "application/json": components["schemas"]["SitemapEntry"][];
         };
       };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
     };
   };
   get_jurisdictions_api_v1_landing_page_jurisdictions_get: {
     parameters: {
       query?: never;
-      header?: {
-        "X-API-Key"?: string;
-      };
+      header?: never;
       path?: never;
       cookie?: never;
     };
@@ -3737,23 +3716,12 @@ export interface operations {
           "application/json": components["schemas"]["LandingPageJurisdiction"][];
         };
       };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
     };
   };
   get_jurisdictions_with_answer_coverage_api_v1_statistics_jurisdictions_with_answer_percentage_get: {
     parameters: {
       query?: never;
-      header?: {
-        "X-API-Key"?: string;
-      };
+      header?: never;
       path?: never;
       cookie?: never;
     };
@@ -3786,15 +3754,6 @@ export interface operations {
           "application/json": components["schemas"]["JurisdictionCoverage"][];
         };
       };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
     };
   };
   count_by_jurisdiction_api_v1_statistics_count_by_jurisdiction_get: {
@@ -3805,9 +3764,7 @@ export interface operations {
         /** @description Optional limit on number of results to return */
         limit?: number | null;
       };
-      header?: {
-        "X-API-Key"?: string;
-      };
+      header?: never;
       path?: never;
       cookie?: never;
     };

--- a/frontend/app/types/openapi.json
+++ b/frontend/app/types/openapi.json
@@ -213,15 +213,6 @@
               "title": "Sort By Date"
             },
             "description": "Sort results by date descending if True."
-          },
-          {
-            "name": "X-API-Key",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "title": "X-Api-Key"
-            }
           }
         ],
         "responses": {
@@ -408,15 +399,6 @@
               "title": "Id"
             },
             "description": "CoLD ID for the record"
-          },
-          {
-            "name": "X-API-Key",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "title": "X-Api-Key"
-            }
           }
         ],
         "responses": {
@@ -717,15 +699,6 @@
               "title": "Order Dir"
             },
             "description": "Sort direction when order_by is provided."
-          },
-          {
-            "name": "X-API-Key",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "title": "X-Api-Key"
-            }
           }
         ],
         "responses": {
@@ -836,15 +809,6 @@
             "schema": {
               "type": "string",
               "title": "Jurisdiction Alpha Code"
-            }
-          },
-          {
-            "name": "X-API-Key",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "title": "X-Api-Key"
             }
           }
         ],
@@ -1320,38 +1284,17 @@
         "tags": ["Sitemap"],
         "summary": "Get All Frontend Urls",
         "operationId": "get_all_frontend_urls_api_v1_sitemap_urls_get",
-        "parameters": [
-          {
-            "name": "X-API-Key",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "title": "X-Api-Key"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/SitemapEntry"
                   },
+                  "type": "array",
                   "title": "Response Get All Frontend Urls Api V1 Sitemap Urls Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -1365,27 +1308,16 @@
         "summary": "Jurisdictions with data availability",
         "description": "Returns ISO Alpha-3 codes and a has_data flag (1/0) depending on whether non-'No data' answers exist.",
         "operationId": "get_jurisdictions_api_v1_landing_page_jurisdictions_get",
-        "parameters": [
-          {
-            "name": "X-API-Key",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "title": "X-Api-Key"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "description": "Array of jurisdictions and availability flag.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/LandingPageJurisdiction"
                   },
+                  "type": "array",
                   "title": "Response Get Jurisdictions Api V1 Landing Page Jurisdictions Get"
                 },
                 "example": [
@@ -1394,16 +1326,6 @@
                     "has_data": 1
                   }
                 ]
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
               }
             }
           }
@@ -1416,27 +1338,16 @@
         "summary": "Get all jurisdictions with answer data percentage",
         "description": "Returns all jurisdictions with their complete data plus the percentage of answers that contain data (not 'no data'). Percentage is calculated per jurisdiction.",
         "operationId": "get_jurisdictions_with_answer_coverage_api_v1_statistics_jurisdictions_with_answer_percentage_get",
-        "parameters": [
-          {
-            "name": "X-API-Key",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "title": "X-Api-Key"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "description": "Array of jurisdictions with all fields plus answer_coverage.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/JurisdictionCoverage"
                   },
+                  "type": "array",
                   "title": "Response Get Jurisdictions With Answer Coverage Api V1 Statistics Jurisdictions With Answer Percentage Get"
                 },
                 "example": [
@@ -1455,16 +1366,6 @@
                     "Answer_Coverage": 85.5
                   }
                 ]
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
               }
             }
           }
@@ -1507,15 +1408,6 @@
               "title": "Limit"
             },
             "description": "Optional limit on number of results to return"
-          },
-          {
-            "name": "X-API-Key",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "title": "X-Api-Key"
-            }
           }
         ],
         "responses": {


### PR DESCRIPTION
## Summary

- Drops `verify_frontend_request` (X-API-Key) from public read GET endpoints in `search`, `landing_page`, `sitemap`, and `statistics` routers; re-applies it on the 3 POST routes in `search.py`. Removes the auth-bypass vector that comes from CF Free's URL-only cache keys, so `api.cold.global` cache rules can ship safely.
- Wraps the Footer Login/Logout link in `<ClientOnly>` with a stable Login fallback so SSR HTML no longer varies by auth state — required for `cold.global` cache rules to actually cache static content pages.
- Regenerates `frontend/app/types/openapi.json` + `api-schema.d.ts` to reflect the auth dependency move.

## Test plan

- [x] `cd backend && make check` (212 passed / 2 skipped, 0 type errors)
- [x] `cd frontend && pnpm run check` (prettier + eslint + vue-tsc + 156 vitest tests pass)
- [ ] After deploy: confirm `curl -sI https://api.cold.global/api/v1/landing-page/jurisdictions` returns 200 without an `X-API-Key` header
- [ ] After deploy: confirm `curl -sI https://api.cold.global/api/v1/feedback/` still returns 403 (auth-gated routes unchanged)
- [ ] After deploy: hard-refresh the homepage and verify Footer renders Login/Logout correctly post-hydration for both auth states

🤖 Generated with [Claude Code](https://claude.com/claude-code)