### PR TITLE
refactor(api): drop POST data-fetching endpoints

### DIFF
--- a/backend/app/routes/ai.py
+++ b/backend/app/routes/ai.py
@@ -3,7 +3,6 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from app.auth import verify_frontend_request
-from app.schemas.requests import ClassifyQueryRequest
 from app.services.ai import QueryClassifier
 
 
@@ -24,29 +23,9 @@ _CLASSIFY_QUERY_RESPONSES: dict[int | str, dict[str, Any]] = {
 }
 
 
-def _do_classify_query(query: str, classifier: QueryClassifier) -> str:
-    classification = classifier.classify_user_query(query)
-    if isinstance(classification, dict):
-        raise HTTPException(status_code=502, detail=classification.get("error", "Upstream AI service error"))
-    return classification
-
-
-@router.post(
-    "/classify_query",
-    summary="Classify a free-text user query into a predefined category",
-    description=_CLASSIFY_QUERY_DESCRIPTION,
-    responses=_CLASSIFY_QUERY_RESPONSES,
-)
-def classify_query(
-    body: ClassifyQueryRequest,
-    classifier: QueryClassifier = Depends(get_query_classifier),
-) -> str:
-    return _do_classify_query(body.query, classifier)
-
-
 @router.get(
     "/classify_query",
-    summary="Classify a free-text user query (GET alternative)",
+    summary="Classify a free-text user query into a predefined category",
     description=_CLASSIFY_QUERY_DESCRIPTION,
     responses=_CLASSIFY_QUERY_RESPONSES,
 )
@@ -54,4 +33,7 @@ def classify_query_get(
     query: Annotated[str, Query(description="Free-text query to classify, e.g. 'How do courts treat party autonomy?'")],
     classifier: QueryClassifier = Depends(get_query_classifier),
 ) -> str:
-    return _do_classify_query(query, classifier)
+    classification = classifier.classify_user_query(query)
+    if isinstance(classification, dict):
+        raise HTTPException(status_code=502, detail=classification.get("error", "Upstream AI service error"))
+    return classification

--- a/backend/app/routes/search.py
+++ b/backend/app/routes/search.py
@@ -5,17 +5,9 @@ from typing import Annotated, Any, Literal
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic.alias_generators import to_camel
 
-from app.auth import verify_frontend_request
 from app.schemas.details import TABLE_DETAIL_MODELS, AnyDetail, DetailBase
 from app.schemas.records import AnyRecord, validate_record
-from app.schemas.requests import (
-    CuratedDetailsRequest,
-    FilterValue,
-    FTFilterOption,
-    FTSFilterOption,
-    FullTableRequest,
-    FullTextSearchRequest,
-)
+from app.schemas.requests import FilterValue, FTFilterOption, FTSFilterOption
 from app.schemas.responses import FullTextSearchResponse, SpecialistResponse
 from app.schemas.search_result import validate_search_result
 from app.services.search import SearchService
@@ -74,14 +66,64 @@ router = APIRouter(
 )
 
 
-def _do_full_text_search(
-    search_string: str | None,
-    filters: list[FTSFilterOption],
-    page: int,
-    page_size: int,
-    sort_by_date: bool,
-    search_service: SearchService,
+@router.get(
+    "/",
+    summary="Full-text search across CoLD data",
+    description=(
+        "Searches across multiple domains (Answers, HCCH Answers, Court Decisions, Domestic Instruments, "
+        "Regional Instruments, International Instruments, Literature, Arbitral Awards, and Arbitral Rules). "
+        "Filter columns are exposed as dedicated repeatable query parameters: "
+        "`tables`, `jurisdictions`, `themes`. Pass each value separately, e.g. "
+        "`?tables=Answers&tables=Court%20Decisions&jurisdictions=Switzerland`. "
+        "You can sort by date and paginate results."
+    ),
+    responses={
+        200: {
+            "description": "Search results including pagination and total matches.",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "query": "example search",
+                        "filters": [{"column": "tables", "values": ["Answers"]}],
+                        "total_matches": 2,
+                        "page": 1,
+                        "page_size": 2,
+                        "results": [
+                            {
+                                "source_table": "Answers",
+                                "id": "CHE_15-TC",
+                                "Title": "…",
+                            },
+                            {
+                                "source_table": "Court Decisions",
+                                "id": "CD-GBR-1167",
+                                "Title": "…",
+                            },
+                        ],
+                    }
+                }
+            },
+        }
+    },
+)
+def handle_full_text_search(
+    search_string: Annotated[str | None, Query(description="Free-text query string")] = None,
+    tables: Annotated[list[str] | None, Query(description="Restrict to source tables (repeatable)")] = None,
+    jurisdictions: Annotated[list[str] | None, Query(description="Filter by jurisdictions (repeatable)")] = None,
+    themes: Annotated[list[str] | None, Query(description="Filter by themes (repeatable)")] = None,
+    page: Annotated[int, Query(ge=1, description="Page number, must be >= 1")] = 1,
+    page_size: Annotated[int, Query(ge=1, le=100, description="Number of results per page")] = 50,
+    sort_by_date: Annotated[bool, Query(description="Sort results by date descending if True.")] = False,
+    search_service: SearchService = Depends(get_search_service),
 ) -> FullTextSearchResponse:
+    filters: list[FTSFilterOption] = []
+    if tables:
+        filters.append(FTSFilterOption(column="tables", values=tables))
+    if jurisdictions:
+        filters.append(FTSFilterOption(column="jurisdictions", values=jurisdictions))
+    if themes:
+        filters.append(FTSFilterOption(column="themes", values=themes))
+
     raw = search_service.full_text_search(
         search_string,
         filters,
@@ -94,7 +136,18 @@ def _do_full_text_search(
     return FullTextSearchResponse(results=validated_results, **raw)
 
 
-def _do_entity_detail(table: str, cold_id: str, search_service: SearchService) -> AnyDetail:
+@router.get(
+    "/details",
+    summary="Fetch a curated record by CoLD ID including relations",
+    description="Given a table and a CoLD ID, returns the record with all first-hop relations in a standardized shape.",
+    response_model=AnyDetail,
+    responses={404: {"description": "Record not found."}},
+)
+def handle_entity_detail(
+    table: Annotated[str, Query(description="Source table name (e.g. 'Answers')")],
+    cold_id: Annotated[str, Query(alias="id", description="CoLD ID for the record")],
+    search_service: SearchService = Depends(get_search_service),
+) -> AnyDetail:
     try:
         result = search_service.get_entity_detail(table, cold_id)
     except ValueError as e:
@@ -106,16 +159,62 @@ def _do_entity_detail(table: str, cold_id: str, search_service: SearchService) -
     return model.model_validate(result)
 
 
-def _do_full_table(
-    table: str,
-    filters: list[FTFilterOption],
-    order_by: str | None,
-    order_dir: str | None,
-    limit: int | None,
-    search_service: SearchService,
+@router.get(
+    "/full_table",
+    summary="Return full or filtered table",
+    description=(
+        "Returns all records from the specified table or a filtered subset. "
+        "Filters use the repeatable `filter` query parameter with format `column:value` "
+        "or `column:val1,val2` for multiple values. Values matching `true`/`false` are "
+        "parsed as booleans; pure-digit strings as integers; everything else stays a string. "
+        "Example: `?table=Court%20Decisions&filter=caseRank:10&filter=jurisdiction:Switzerland`."
+    ),
+    responses={
+        200: {
+            "description": "Array of transformed records from the requested table.",
+            "content": {
+                "application/json": {
+                    "example": [
+                        {
+                            "source_table": "Answers",
+                            "id": "CHE_15-TC",
+                            "Jurisdictions": ["Switzerland"],
+                            "Title": "…",
+                        }
+                    ]
+                }
+            },
+        },
+        400: {"description": "Missing or invalid table parameter."},
+        500: {"description": "Server error while querying the table."},
+    },
+)
+def return_full_table(
+    table: Annotated[str, Query(description="Source table name")],
+    filter_: Annotated[
+        list[str] | None,
+        Query(
+            alias="filter",
+            description="Filter as 'column:value' or 'column:val1,val2'. Repeatable.",
+        ),
+    ] = None,
+    limit: Annotated[
+        int | None,
+        Query(ge=1, le=10000, description="Maximum number of rows to return. Omit for no limit."),
+    ] = None,
+    order_by: Annotated[
+        str | None,
+        Query(description="Column name to sort by (camelCase or snake_case). Unknown columns are ignored."),
+    ] = None,
+    order_dir: Annotated[
+        Literal["asc", "desc"] | None,
+        Query(description="Sort direction when order_by is provided."),
+    ] = "desc",
+    search_service: SearchService = Depends(get_search_service),
 ) -> list[AnyRecord]:
     if not table:
         raise HTTPException(status_code=400, detail="No table provided")
+    filters = [_parse_full_table_filter(f) for f in (filter_ or [])]
     try:
         if filters:
             results = search_service.filtered_table(
@@ -139,222 +238,6 @@ def _do_full_table(
         raise HTTPException(status_code=500, detail="Failed to query table") from e
 
     return [validate_record(_camel_keys(r)) for r in results]
-
-
-_FULL_TEXT_SEARCH_RESPONSES: dict[int | str, dict[str, Any]] = {
-    200: {
-        "description": "Search results including pagination and total matches.",
-        "content": {
-            "application/json": {
-                "example": {
-                    "query": "example search",
-                    "filters": [{"column": "tables", "values": ["Answers"]}],
-                    "total_matches": 2,
-                    "page": 1,
-                    "page_size": 2,
-                    "results": [
-                        {
-                            "source_table": "Answers",
-                            "id": "CHE_15-TC",
-                            "Title": "…",
-                        },
-                        {
-                            "source_table": "Court Decisions",
-                            "id": "CD-GBR-1167",
-                            "Title": "…",
-                        },
-                    ],
-                }
-            }
-        },
-    }
-}
-
-_FULL_TEXT_SEARCH_DESCRIPTION = (
-    "Searches across multiple domains (Answers, HCCH Answers, Court Decisions, Domestic Instruments, "
-    "Regional Instruments, International Instruments, Literature, Arbitral Awards, and Arbitral Rules). "
-    "Filters support user-facing fields like 'tables', 'Jurisdictions', or 'Themes'. "
-    "You can sort by date and paginate results."
-)
-
-
-@router.post(
-    "/",
-    summary="Full-text search across CoLD data",
-    description=_FULL_TEXT_SEARCH_DESCRIPTION,
-    responses=_FULL_TEXT_SEARCH_RESPONSES,
-    dependencies=[Depends(verify_frontend_request)],
-)
-def handle_full_text_search(
-    body: FullTextSearchRequest,
-    search_service: SearchService = Depends(get_search_service),
-) -> FullTextSearchResponse:
-    response_type = body.response_type or "parsed"
-    if response_type != "parsed":
-        raise HTTPException(
-            status_code=400,
-            detail="Only response_type='parsed' is supported for typed search results",
-        )
-    return _do_full_text_search(
-        body.search_string,
-        body.filters or [],
-        body.page,
-        body.page_size,
-        body.sort_by_date or False,
-        search_service,
-    )
-
-
-@router.get(
-    "/",
-    summary="Full-text search across CoLD data (GET alternative)",
-    description=(
-        f"{_FULL_TEXT_SEARCH_DESCRIPTION}\n\n"
-        "Filter columns are exposed as dedicated repeatable query parameters: "
-        "`tables`, `jurisdictions`, `themes`. Pass each value separately, e.g. "
-        "`?tables=Answers&tables=Court%20Decisions&jurisdictions=Switzerland`."
-    ),
-    responses=_FULL_TEXT_SEARCH_RESPONSES,
-)
-def handle_full_text_search_get(
-    search_string: Annotated[str | None, Query(description="Free-text query string")] = None,
-    tables: Annotated[list[str] | None, Query(description="Restrict to source tables (repeatable)")] = None,
-    jurisdictions: Annotated[list[str] | None, Query(description="Filter by jurisdictions (repeatable)")] = None,
-    themes: Annotated[list[str] | None, Query(description="Filter by themes (repeatable)")] = None,
-    page: Annotated[int, Query(ge=1, description="Page number, must be >= 1")] = 1,
-    page_size: Annotated[int, Query(ge=1, le=100, description="Number of results per page")] = 50,
-    sort_by_date: Annotated[bool, Query(description="Sort results by date descending if True.")] = False,
-    search_service: SearchService = Depends(get_search_service),
-) -> FullTextSearchResponse:
-    filters: list[FTSFilterOption] = []
-    if tables:
-        filters.append(FTSFilterOption(column="tables", values=tables))
-    if jurisdictions:
-        filters.append(FTSFilterOption(column="jurisdictions", values=jurisdictions))
-    if themes:
-        filters.append(FTSFilterOption(column="themes", values=themes))
-    return _do_full_text_search(search_string, filters, page, page_size, sort_by_date, search_service)
-
-
-_ENTITY_DETAIL_RESPONSES: dict[int | str, dict[str, Any]] = {404: {"description": "Record not found."}}
-_ENTITY_DETAIL_DESCRIPTION = (
-    "Given a table and a CoLD ID, returns the record with all first-hop relations in a standardized shape."
-)
-
-
-@router.post(
-    "/details",
-    summary="Fetch a curated record by CoLD ID including relations",
-    description=_ENTITY_DETAIL_DESCRIPTION,
-    response_model=AnyDetail,
-    responses=_ENTITY_DETAIL_RESPONSES,
-    dependencies=[Depends(verify_frontend_request)],
-)
-def handle_entity_detail(
-    body: CuratedDetailsRequest,
-    search_service: SearchService = Depends(get_search_service),
-) -> AnyDetail:
-    return _do_entity_detail(body.table, body.id, search_service)
-
-
-@router.get(
-    "/details",
-    summary="Fetch a curated record by CoLD ID (GET alternative)",
-    description=_ENTITY_DETAIL_DESCRIPTION,
-    response_model=AnyDetail,
-    responses=_ENTITY_DETAIL_RESPONSES,
-)
-def handle_entity_detail_get(
-    table: Annotated[str, Query(description="Source table name (e.g. 'Answers')")],
-    cold_id: Annotated[str, Query(alias="id", description="CoLD ID for the record")],
-    search_service: SearchService = Depends(get_search_service),
-) -> AnyDetail:
-    return _do_entity_detail(table, cold_id, search_service)
-
-
-_FULL_TABLE_RESPONSES: dict[int | str, dict[str, Any]] = {
-    200: {
-        "description": "Array of transformed records from the requested table.",
-        "content": {
-            "application/json": {
-                "example": [
-                    {
-                        "source_table": "Answers",
-                        "id": "CHE_15-TC",
-                        "Jurisdictions": ["Switzerland"],
-                        "Title": "…",
-                    }
-                ]
-            }
-        },
-    },
-    400: {"description": "Missing or invalid table parameter."},
-    500: {"description": "Server error while querying the table."},
-}
-_FULL_TABLE_DESCRIPTION = (
-    "Returns all records from the specified table or a filtered subset. "
-    "Filters accept user-facing field names and values (mapping-aware)."
-)
-
-
-@router.post(
-    "/full_table",
-    summary="Return full or filtered table",
-    description=_FULL_TABLE_DESCRIPTION,
-    responses=_FULL_TABLE_RESPONSES,
-    dependencies=[Depends(verify_frontend_request)],
-)
-def return_full_table(
-    body: FullTableRequest,
-    search_service: SearchService = Depends(get_search_service),
-) -> list[AnyRecord]:
-    return _do_full_table(
-        body.table,
-        body.filters or [],
-        body.order_by,
-        body.order_dir,
-        body.limit,
-        search_service,
-    )
-
-
-@router.get(
-    "/full_table",
-    summary="Return full or filtered table (GET alternative)",
-    description=(
-        f"{_FULL_TABLE_DESCRIPTION}\n\n"
-        "Filters use the repeatable `filter` query parameter with format `column:value` "
-        "or `column:val1,val2` for multiple values. Values matching `true`/`false` are "
-        "parsed as booleans; pure-digit strings as integers; everything else stays a string. "
-        "Example: `?table=Court%20Decisions&filter=caseRank:10&filter=jurisdiction:Switzerland`."
-    ),
-    responses=_FULL_TABLE_RESPONSES,
-)
-def return_full_table_get(
-    table: Annotated[str, Query(description="Source table name")],
-    filter_: Annotated[
-        list[str] | None,
-        Query(
-            alias="filter",
-            description="Filter as 'column:value' or 'column:val1,val2'. Repeatable.",
-        ),
-    ] = None,
-    limit: Annotated[
-        int | None,
-        Query(ge=1, le=10000, description="Maximum number of rows to return. Omit for no limit."),
-    ] = None,
-    order_by: Annotated[
-        str | None,
-        Query(description="Column name to sort by (camelCase or snake_case). Unknown columns are ignored."),
-    ] = None,
-    order_dir: Annotated[
-        Literal["asc", "desc"] | None,
-        Query(description="Sort direction when order_by is provided."),
-    ] = "desc",
-    search_service: SearchService = Depends(get_search_service),
-) -> list[AnyRecord]:
-    filters = [_parse_full_table_filter(f) for f in (filter_ or [])]
-    return _do_full_table(table, filters, order_by, order_dir, limit, search_service)
 
 
 @router.get(

--- a/backend/app/schemas/requests.py
+++ b/backend/app/schemas/requests.py
@@ -1,62 +1,9 @@
-from typing import Literal
-
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 
 class FTSFilterOption(BaseModel):
     column: str
     values: list[str] | str
-
-
-class FullTextSearchRequest(BaseModel):
-    search_string: str | None = None
-    filters: list[FTSFilterOption] | None = None
-    page: int = Field(1, ge=1, description="Page number, must be >= 1")
-    page_size: int = Field(50, ge=1, le=100, description="Number of results per page")
-    sort_by_date: bool | None = Field(False, description="Sort results by date descending if True.")
-    response_type: Literal["parsed"] | None = Field(
-        "parsed",
-        description="Response data format. Only 'parsed' is supported.",
-    )
-    model_config = {
-        "json_schema_extra": {
-            "examples": [
-                {
-                    "search_string": "",
-                    "filters": [
-                        {"column": "tables", "values": ["Answers", "Court Decisions"]},
-                        {
-                            "column": "jurisdictions",
-                            "values": ["Switzerland", "France"],
-                        },
-                        {
-                            "column": "Themes",
-                            "values": ["Party autonomy", "Freedom of choice"],
-                        },
-                    ],
-                    "page": 1,
-                    "page_size": 100,
-                    "sort_by_date": True,
-                    "response_type": "parsed",
-                },
-            ]
-        }
-    }
-
-
-class CuratedDetailsRequest(BaseModel):
-    table: str
-    id: str
-    model_config = {
-        "json_schema_extra": {
-            "examples": [
-                {
-                    "table": "Answers",
-                    "id": "CHE_15-TC",
-                },
-            ]
-        }
-    }
 
 
 FilterValue = str | int | bool
@@ -65,51 +12,3 @@ FilterValue = str | int | bool
 class FTFilterOption(BaseModel):
     column: str
     value: FilterValue | list[FilterValue]
-
-
-class FullTableRequest(BaseModel):
-    table: str
-    filters: list[FTFilterOption] | None = None
-    response_type: Literal["parsed"] | None = Field(
-        "parsed",
-        description="Response data format. Only 'parsed' is supported.",
-    )
-    limit: int | None = Field(
-        None,
-        ge=1,
-        le=10000,
-        description="Maximum number of rows to return. Omit for no limit.",
-    )
-    order_by: str | None = Field(
-        None,
-        description="Column name to sort by (camelCase or snake_case). Unknown columns are ignored.",
-    )
-    order_dir: Literal["asc", "desc"] | None = Field(
-        "desc",
-        description="Sort direction when order_by is provided.",
-    )
-    model_config = {
-        "json_schema_extra": {
-            "examples": [
-                {
-                    "table": "Answers",
-                    "filters": [{"column": "Jurisdictions", "value": "Switzerland"}],
-                    "response_type": "parsed",
-                    "limit": 10,
-                    "order_by": "date",
-                    "order_dir": "desc",
-                },
-            ]
-        }
-    }
-
-
-class ClassifyQueryRequest(BaseModel):
-    query: str
-    model_config = {
-        "json_schema_extra": {
-            "examples": [
-                {"query": "How do courts treat party autonomy?"},
-            ]
-        }
-    }

--- a/frontend/app/composables/useFullTable.ts
+++ b/frontend/app/composables/useFullTable.ts
@@ -29,8 +29,7 @@ const encodeFilter = <T extends TableName>(filter: TypedFilter<T>): string => {
   if (serialized.includes(",")) {
     throw new Error(
       `Filter value for column "${String(filter.column)}" contains a comma; ` +
-        "the GET /search/full_table wire format reserves ',' as a multi-value separator. " +
-        "Use the POST endpoint for values containing commas.",
+        "the GET /search/full_table wire format reserves ',' as a multi-value separator.",
     );
   }
   return `${String(filter.column)}:${serialized}`;

--- a/frontend/app/pages/domestic-instrument/new.vue
+++ b/frontend/app/pages/domestic-instrument/new.vue
@@ -278,13 +278,9 @@ const comments = ref("");
 
 const loadJurisdictions = async () => {
   try {
-    const response = await fetch(`/api/proxy/search/full_table`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ table: "Jurisdictions", filters: [] }),
-    });
+    const response = await fetch(
+      `/api/proxy/search/full_table?table=Jurisdictions`,
+    );
 
     if (!response.ok) throw new Error("Failed to load jurisdictions");
 

--- a/frontend/app/pages/international-instrument/[...slug].vue
+++ b/frontend/app/pages/international-instrument/[...slug].vue
@@ -265,16 +265,11 @@ async function fetchInstrument() {
       return;
     }
 
-    const response = await fetch(`/api/proxy/search/details`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        table: "International Instruments",
-        id: instrumentId.value,
-      }),
+    const params = new URLSearchParams({
+      table: "International Instruments",
+      id: instrumentId.value,
     });
+    const response = await fetch(`/api/proxy/search/details?${params}`);
     const responseText = await response.text();
     if (!response.ok) throw new Error("Failed to fetch instrument");
     const data = JSON.parse(responseText);

--- a/frontend/app/pages/literature/new.vue
+++ b/frontend/app/pages/literature/new.vue
@@ -197,13 +197,9 @@ const comments = ref("");
 
 const loadJurisdictions = async () => {
   try {
-    const response = await fetch(`/api/proxy/search/full_table`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ table: "Jurisdictions", filters: [] }),
-    });
+    const response = await fetch(
+      `/api/proxy/search/full_table?table=Jurisdictions`,
+    );
 
     if (!response.ok) throw new Error("Failed to load jurisdictions");
 

--- a/frontend/app/types/api-schema.d.ts
+++ b/frontend/app/types/api-schema.d.ts
@@ -12,18 +12,12 @@ export interface paths {
       cookie?: never;
     };
     /**
-     * Full-text search across CoLD data (GET alternative)
-     * @description Searches across multiple domains (Answers, HCCH Answers, Court Decisions, Domestic Instruments, Regional Instruments, International Instruments, Literature, Arbitral Awards, and Arbitral Rules). Filters support user-facing fields like 'tables', 'Jurisdictions', or 'Themes'. You can sort by date and paginate results.
-     *
-     *     Filter columns are exposed as dedicated repeatable query parameters: `tables`, `jurisdictions`, `themes`. Pass each value separately, e.g. `?tables=Answers&tables=Court%20Decisions&jurisdictions=Switzerland`.
-     */
-    get: operations["handle_full_text_search_get_api_v1_search__get"];
-    put?: never;
-    /**
      * Full-text search across CoLD data
-     * @description Searches across multiple domains (Answers, HCCH Answers, Court Decisions, Domestic Instruments, Regional Instruments, International Instruments, Literature, Arbitral Awards, and Arbitral Rules). Filters support user-facing fields like 'tables', 'Jurisdictions', or 'Themes'. You can sort by date and paginate results.
+     * @description Searches across multiple domains (Answers, HCCH Answers, Court Decisions, Domestic Instruments, Regional Instruments, International Instruments, Literature, Arbitral Awards, and Arbitral Rules). Filter columns are exposed as dedicated repeatable query parameters: `tables`, `jurisdictions`, `themes`. Pass each value separately, e.g. `?tables=Answers&tables=Court%20Decisions&jurisdictions=Switzerland`. You can sort by date and paginate results.
      */
-    post: operations["handle_full_text_search_api_v1_search__post"];
+    get: operations["handle_full_text_search_api_v1_search__get"];
+    put?: never;
+    post?: never;
     delete?: never;
     options?: never;
     head?: never;
@@ -38,16 +32,12 @@ export interface paths {
       cookie?: never;
     };
     /**
-     * Fetch a curated record by CoLD ID (GET alternative)
-     * @description Given a table and a CoLD ID, returns the record with all first-hop relations in a standardized shape.
-     */
-    get: operations["handle_entity_detail_get_api_v1_search_details_get"];
-    put?: never;
-    /**
      * Fetch a curated record by CoLD ID including relations
      * @description Given a table and a CoLD ID, returns the record with all first-hop relations in a standardized shape.
      */
-    post: operations["handle_entity_detail_api_v1_search_details_post"];
+    get: operations["handle_entity_detail_api_v1_search_details_get"];
+    put?: never;
+    post?: never;
     delete?: never;
     options?: never;
     head?: never;
@@ -62,18 +52,12 @@ export interface paths {
       cookie?: never;
     };
     /**
-     * Return full or filtered table (GET alternative)
-     * @description Returns all records from the specified table or a filtered subset. Filters accept user-facing field names and values (mapping-aware).
-     *
-     *     Filters use the repeatable `filter` query parameter with format `column:value` or `column:val1,val2` for multiple values. Values matching `true`/`false` are parsed as booleans; pure-digit strings as integers; everything else stays a string. Example: `?table=Court%20Decisions&filter=caseRank:10&filter=jurisdiction:Switzerland`.
-     */
-    get: operations["return_full_table_get_api_v1_search_full_table_get"];
-    put?: never;
-    /**
      * Return full or filtered table
-     * @description Returns all records from the specified table or a filtered subset. Filters accept user-facing field names and values (mapping-aware).
+     * @description Returns all records from the specified table or a filtered subset. Filters use the repeatable `filter` query parameter with format `column:value` or `column:val1,val2` for multiple values. Values matching `true`/`false` are parsed as booleans; pure-digit strings as integers; everything else stays a string. Example: `?table=Court%20Decisions&filter=caseRank:10&filter=jurisdiction:Switzerland`.
      */
-    post: operations["return_full_table_api_v1_search_full_table_post"];
+    get: operations["return_full_table_api_v1_search_full_table_get"];
+    put?: never;
+    post?: never;
     delete?: never;
     options?: never;
     head?: never;
@@ -108,16 +92,12 @@ export interface paths {
       cookie?: never;
     };
     /**
-     * Classify a free-text user query (GET alternative)
+     * Classify a free-text user query into a predefined category
      * @description Uses an external model to classify the user's query into one of the predefined CoLD categories.
      */
     get: operations["classify_query_get_api_v1_ai_classify_query_get"];
     put?: never;
-    /**
-     * Classify a free-text user query into a predefined category
-     * @description Uses an external model to classify the user's query into one of the predefined CoLD categories.
-     */
-    post: operations["classify_query_api_v1_ai_classify_query_post"];
+    post?: never;
     delete?: never;
     options?: never;
     head?: never;
@@ -1038,15 +1018,6 @@ export interface components {
       themes?: string | null;
       arbitralInstitutions?: string | null;
     };
-    /**
-     * ClassifyQueryRequest
-     * @example {
-     *       "query": "How do courts treat party autonomy?"
-     *     }
-     */
-    ClassifyQueryRequest: {
-      query: string;
-    };
     /** ConfirmAnalysisRequest */
     ConfirmAnalysisRequest: {
       /** @description Draft ID from upload response */
@@ -1249,17 +1220,6 @@ export interface components {
       submitter_email?: string | null;
       /** @description Submitter comments */
       submitter_comments?: string | null;
-    };
-    /**
-     * CuratedDetailsRequest
-     * @example {
-     *       "id": "CHE_15-TC",
-     *       "table": "Answers"
-     *     }
-     */
-    CuratedDetailsRequest: {
-      table: string;
-      id: string;
     };
     /** DetailBase */
     DetailBase: {
@@ -1600,11 +1560,6 @@ export interface components {
       | "arbitral_rule"
       | "question"
       | "jurisdiction";
-    /** FTFilterOption */
-    FTFilterOption: {
-      column: string;
-      value: string | number | boolean | (string | number | boolean)[];
-    };
     /** FTSFilterOption */
     FTSFilterOption: {
       column: string;
@@ -1669,97 +1624,6 @@ export interface components {
     /** FeedbackUpdate */
     FeedbackUpdate: {
       moderationStatus: components["schemas"]["FeedbackModerationStatus"];
-    };
-    /**
-     * FullTableRequest
-     * @example {
-     *       "filters": [
-     *         {
-     *           "column": "Jurisdictions",
-     *           "value": "Switzerland"
-     *         }
-     *       ],
-     *       "limit": 10,
-     *       "order_by": "date",
-     *       "order_dir": "desc",
-     *       "response_type": "parsed",
-     *       "table": "Answers"
-     *     }
-     */
-    FullTableRequest: {
-      table: string;
-      filters?: components["schemas"]["FTFilterOption"][] | null;
-      /**
-       * @description Response data format. Only 'parsed' is supported.
-       * @default parsed
-       */
-      response_type: "parsed" | null;
-      /** @description Maximum number of rows to return. Omit for no limit. */
-      limit?: number | null;
-      /** @description Column name to sort by (camelCase or snake_case). Unknown columns are ignored. */
-      order_by?: string | null;
-      /**
-       * @description Sort direction when order_by is provided.
-       * @default desc
-       */
-      order_dir: ("asc" | "desc") | null;
-    };
-    /**
-     * FullTextSearchRequest
-     * @example {
-     *       "filters": [
-     *         {
-     *           "column": "tables",
-     *           "values": [
-     *             "Answers",
-     *             "Court Decisions"
-     *           ]
-     *         },
-     *         {
-     *           "column": "jurisdictions",
-     *           "values": [
-     *             "Switzerland",
-     *             "France"
-     *           ]
-     *         },
-     *         {
-     *           "column": "Themes",
-     *           "values": [
-     *             "Party autonomy",
-     *             "Freedom of choice"
-     *           ]
-     *         }
-     *       ],
-     *       "page": 1,
-     *       "page_size": 100,
-     *       "response_type": "parsed",
-     *       "search_string": "",
-     *       "sort_by_date": true
-     *     }
-     */
-    FullTextSearchRequest: {
-      search_string?: string | null;
-      filters?: components["schemas"]["FTSFilterOption"][] | null;
-      /**
-       * @description Page number, must be >= 1
-       * @default 1
-       */
-      page: number;
-      /**
-       * @description Number of results per page
-       * @default 50
-       */
-      page_size: number;
-      /**
-       * @description Sort results by date descending if True.
-       * @default false
-       */
-      sort_by_date: boolean | null;
-      /**
-       * @description Response data format. Only 'parsed' is supported.
-       * @default parsed
-       */
-      response_type: "parsed" | null;
     };
     /** FullTextSearchResponse */
     FullTextSearchResponse: {
@@ -2913,7 +2777,7 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
-  handle_full_text_search_get_api_v1_search__get: {
+  handle_full_text_search_api_v1_search__get: {
     parameters: {
       query?: {
         /** @description Free-text query string */
@@ -2985,70 +2849,7 @@ export interface operations {
       };
     };
   };
-  handle_full_text_search_api_v1_search__post: {
-    parameters: {
-      query?: never;
-      header?: {
-        "X-API-Key"?: string;
-      };
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["FullTextSearchRequest"];
-      };
-    };
-    responses: {
-      /** @description Search results including pagination and total matches. */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          /**
-           * @example {
-           *       "query": "example search",
-           *       "filters": [
-           *         {
-           *           "column": "tables",
-           *           "values": [
-           *             "Answers"
-           *           ]
-           *         }
-           *       ],
-           *       "total_matches": 2,
-           *       "page": 1,
-           *       "page_size": 2,
-           *       "results": [
-           *         {
-           *           "source_table": "Answers",
-           *           "id": "CHE_15-TC",
-           *           "Title": "…"
-           *         },
-           *         {
-           *           "source_table": "Court Decisions",
-           *           "id": "CD-GBR-1167",
-           *           "Title": "…"
-           *         }
-           *       ]
-           *     }
-           */
-          "application/json": components["schemas"]["FullTextSearchResponse"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  handle_entity_detail_get_api_v1_search_details_get: {
+  handle_entity_detail_api_v1_search_details_get: {
     parameters: {
       query: {
         /** @description Source table name (e.g. 'Answers') */
@@ -3107,67 +2908,7 @@ export interface operations {
       };
     };
   };
-  handle_entity_detail_api_v1_search_details_post: {
-    parameters: {
-      query?: never;
-      header?: {
-        "X-API-Key"?: string;
-      };
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CuratedDetailsRequest"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json":
-            | components["schemas"]["AnswerDetail"]
-            | components["schemas"]["HcchAnswerDetail"]
-            | components["schemas"]["QuestionDetail"]
-            | components["schemas"]["JurisdictionDetail"]
-            | components["schemas"]["CourtDecisionDetail"]
-            | components["schemas"]["DomesticInstrumentDetail"]
-            | components["schemas"]["DomesticLegalProvisionDetail"]
-            | components["schemas"]["RegionalInstrumentDetail"]
-            | components["schemas"]["RegionalLegalProvisionDetail"]
-            | components["schemas"]["InternationalInstrumentDetail"]
-            | components["schemas"]["InternationalLegalProvisionDetail"]
-            | components["schemas"]["LiteratureDetail"]
-            | components["schemas"]["ArbitralAwardDetail"]
-            | components["schemas"]["ArbitralInstitutionDetail"]
-            | components["schemas"]["ArbitralRuleDetail"]
-            | components["schemas"]["ArbitralProvisionDetail"]
-            | components["schemas"]["SpecialistDetail"]
-            | components["schemas"]["DetailBase"];
-        };
-      };
-      /** @description Record not found. */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  return_full_table_get_api_v1_search_full_table_get: {
+  return_full_table_api_v1_search_full_table_get: {
     parameters: {
       query: {
         /** @description Source table name */
@@ -3186,85 +2927,6 @@ export interface operations {
       cookie?: never;
     };
     requestBody?: never;
-    responses: {
-      /** @description Array of transformed records from the requested table. */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          /**
-           * @example [
-           *       {
-           *         "source_table": "Answers",
-           *         "id": "CHE_15-TC",
-           *         "Jurisdictions": [
-           *           "Switzerland"
-           *         ],
-           *         "Title": "…"
-           *       }
-           *     ]
-           */
-          "application/json": (
-            | components["schemas"]["AnswerRecord"]
-            | components["schemas"]["CourtDecisionRecord"]
-            | components["schemas"]["DomesticInstrumentRecord"]
-            | components["schemas"]["InternationalInstrumentRecord"]
-            | components["schemas"]["RegionalInstrumentRecord"]
-            | components["schemas"]["LiteratureRecord"]
-            | components["schemas"]["ArbitralAwardRecord"]
-            | components["schemas"]["ArbitralInstitutionRecord"]
-            | components["schemas"]["ArbitralProvisionRecord"]
-            | components["schemas"]["ArbitralRuleRecord"]
-            | components["schemas"]["DomesticLegalProvisionRecord"]
-            | components["schemas"]["InternationalLegalProvisionRecord"]
-            | components["schemas"]["RegionalLegalProvisionRecord"]
-            | components["schemas"]["JurisdictionRecord"]
-            | components["schemas"]["QuestionRecord"]
-            | components["schemas"]["SpecialistRecord"]
-            | components["schemas"]["RecordBase"]
-          )[];
-        };
-      };
-      /** @description Missing or invalid table parameter. */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-      /** @description Server error while querying the table. */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  return_full_table_api_v1_search_full_table_post: {
-    parameters: {
-      query?: never;
-      header?: {
-        "X-API-Key"?: string;
-      };
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["FullTableRequest"];
-      };
-    };
     responses: {
       /** @description Array of transformed records from the requested table. */
       200: {
@@ -3404,49 +3066,6 @@ export interface operations {
       cookie?: never;
     };
     requestBody?: never;
-    responses: {
-      /** @description Classification result */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          /** @example Party autonomy (concept) */
-          "application/json": string;
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-      /** @description Upstream AI service error. */
-      502: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  classify_query_api_v1_ai_classify_query_post: {
-    parameters: {
-      query?: never;
-      header?: {
-        "X-API-Key"?: string;
-      };
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ClassifyQueryRequest"];
-      };
-    };
     responses: {
       /** @description Classification result */
       200: {

--- a/frontend/app/types/openapi.json
+++ b/frontend/app/types/openapi.json
@@ -15,84 +15,11 @@
   },
   "paths": {
     "/search/": {
-      "post": {
-        "tags": ["Search"],
-        "summary": "Full-text search across CoLD data",
-        "description": "Searches across multiple domains (Answers, HCCH Answers, Court Decisions, Domestic Instruments, Regional Instruments, International Instruments, Literature, Arbitral Awards, and Arbitral Rules). Filters support user-facing fields like 'tables', 'Jurisdictions', or 'Themes'. You can sort by date and paginate results.",
-        "operationId": "handle_full_text_search_api_v1_search__post",
-        "parameters": [
-          {
-            "name": "X-API-Key",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "title": "X-Api-Key"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/FullTextSearchRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Search results including pagination and total matches.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FullTextSearchResponse"
-                },
-                "example": {
-                  "query": "example search",
-                  "filters": [
-                    {
-                      "column": "tables",
-                      "values": ["Answers"]
-                    }
-                  ],
-                  "total_matches": 2,
-                  "page": 1,
-                  "page_size": 2,
-                  "results": [
-                    {
-                      "source_table": "Answers",
-                      "id": "CHE_15-TC",
-                      "Title": "\u2026"
-                    },
-                    {
-                      "source_table": "Court Decisions",
-                      "id": "CD-GBR-1167",
-                      "Title": "\u2026"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
       "get": {
         "tags": ["Search"],
-        "summary": "Full-text search across CoLD data (GET alternative)",
-        "description": "Searches across multiple domains (Answers, HCCH Answers, Court Decisions, Domestic Instruments, Regional Instruments, International Instruments, Literature, Arbitral Awards, and Arbitral Rules). Filters support user-facing fields like 'tables', 'Jurisdictions', or 'Themes'. You can sort by date and paginate results.\n\nFilter columns are exposed as dedicated repeatable query parameters: `tables`, `jurisdictions`, `themes`. Pass each value separately, e.g. `?tables=Answers&tables=Court%20Decisions&jurisdictions=Switzerland`.",
-        "operationId": "handle_full_text_search_get_api_v1_search__get",
+        "summary": "Full-text search across CoLD data",
+        "description": "Searches across multiple domains (Answers, HCCH Answers, Court Decisions, Domestic Instruments, Regional Instruments, International Instruments, Literature, Arbitral Awards, and Arbitral Rules). Filter columns are exposed as dedicated repeatable query parameters: `tables`, `jurisdictions`, `themes`. Pass each value separately, e.g. `?tables=Answers&tables=Court%20Decisions&jurisdictions=Switzerland`. You can sort by date and paginate results.",
+        "operationId": "handle_full_text_search_api_v1_search__get",
         "parameters": [
           {
             "name": "search_string",
@@ -264,119 +191,11 @@
       }
     },
     "/search/details": {
-      "post": {
+      "get": {
         "tags": ["Search"],
         "summary": "Fetch a curated record by CoLD ID including relations",
         "description": "Given a table and a CoLD ID, returns the record with all first-hop relations in a standardized shape.",
-        "operationId": "handle_entity_detail_api_v1_search_details_post",
-        "parameters": [
-          {
-            "name": "X-API-Key",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "title": "X-Api-Key"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CuratedDetailsRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/AnswerDetail"
-                    },
-                    {
-                      "$ref": "#/components/schemas/HcchAnswerDetail"
-                    },
-                    {
-                      "$ref": "#/components/schemas/QuestionDetail"
-                    },
-                    {
-                      "$ref": "#/components/schemas/JurisdictionDetail"
-                    },
-                    {
-                      "$ref": "#/components/schemas/CourtDecisionDetail"
-                    },
-                    {
-                      "$ref": "#/components/schemas/DomesticInstrumentDetail"
-                    },
-                    {
-                      "$ref": "#/components/schemas/DomesticLegalProvisionDetail"
-                    },
-                    {
-                      "$ref": "#/components/schemas/RegionalInstrumentDetail"
-                    },
-                    {
-                      "$ref": "#/components/schemas/RegionalLegalProvisionDetail"
-                    },
-                    {
-                      "$ref": "#/components/schemas/InternationalInstrumentDetail"
-                    },
-                    {
-                      "$ref": "#/components/schemas/InternationalLegalProvisionDetail"
-                    },
-                    {
-                      "$ref": "#/components/schemas/LiteratureDetail"
-                    },
-                    {
-                      "$ref": "#/components/schemas/ArbitralAwardDetail"
-                    },
-                    {
-                      "$ref": "#/components/schemas/ArbitralInstitutionDetail"
-                    },
-                    {
-                      "$ref": "#/components/schemas/ArbitralRuleDetail"
-                    },
-                    {
-                      "$ref": "#/components/schemas/ArbitralProvisionDetail"
-                    },
-                    {
-                      "$ref": "#/components/schemas/SpecialistDetail"
-                    },
-                    {
-                      "$ref": "#/components/schemas/DetailBase"
-                    }
-                  ],
-                  "title": "Response Handle Entity Detail Api V1 Search Details Post"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Record not found."
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "tags": ["Search"],
-        "summary": "Fetch a curated record by CoLD ID (GET alternative)",
-        "description": "Given a table and a CoLD ID, returns the record with all first-hop relations in a standardized shape.",
-        "operationId": "handle_entity_detail_get_api_v1_search_details_get",
+        "operationId": "handle_entity_detail_api_v1_search_details_get",
         "parameters": [
           {
             "name": "table",
@@ -463,7 +282,7 @@
                       "$ref": "#/components/schemas/DetailBase"
                     }
                   ],
-                  "title": "Response Handle Entity Detail Get Api V1 Search Details Get"
+                  "title": "Response Handle Entity Detail Api V1 Search Details Get"
                 }
               }
             }
@@ -485,130 +304,11 @@
       }
     },
     "/search/full_table": {
-      "post": {
-        "tags": ["Search"],
-        "summary": "Return full or filtered table",
-        "description": "Returns all records from the specified table or a filtered subset. Filters accept user-facing field names and values (mapping-aware).",
-        "operationId": "return_full_table_api_v1_search_full_table_post",
-        "parameters": [
-          {
-            "name": "X-API-Key",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "title": "X-Api-Key"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/FullTableRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Array of transformed records from the requested table.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/AnswerRecord"
-                      },
-                      {
-                        "$ref": "#/components/schemas/CourtDecisionRecord"
-                      },
-                      {
-                        "$ref": "#/components/schemas/DomesticInstrumentRecord"
-                      },
-                      {
-                        "$ref": "#/components/schemas/InternationalInstrumentRecord"
-                      },
-                      {
-                        "$ref": "#/components/schemas/RegionalInstrumentRecord"
-                      },
-                      {
-                        "$ref": "#/components/schemas/LiteratureRecord"
-                      },
-                      {
-                        "$ref": "#/components/schemas/ArbitralAwardRecord"
-                      },
-                      {
-                        "$ref": "#/components/schemas/ArbitralInstitutionRecord"
-                      },
-                      {
-                        "$ref": "#/components/schemas/ArbitralProvisionRecord"
-                      },
-                      {
-                        "$ref": "#/components/schemas/ArbitralRuleRecord"
-                      },
-                      {
-                        "$ref": "#/components/schemas/DomesticLegalProvisionRecord"
-                      },
-                      {
-                        "$ref": "#/components/schemas/InternationalLegalProvisionRecord"
-                      },
-                      {
-                        "$ref": "#/components/schemas/RegionalLegalProvisionRecord"
-                      },
-                      {
-                        "$ref": "#/components/schemas/JurisdictionRecord"
-                      },
-                      {
-                        "$ref": "#/components/schemas/QuestionRecord"
-                      },
-                      {
-                        "$ref": "#/components/schemas/SpecialistRecord"
-                      },
-                      {
-                        "$ref": "#/components/schemas/RecordBase"
-                      }
-                    ]
-                  },
-                  "title": "Response Return Full Table Api V1 Search Full Table Post"
-                },
-                "example": [
-                  {
-                    "source_table": "Answers",
-                    "id": "CHE_15-TC",
-                    "Jurisdictions": ["Switzerland"],
-                    "Title": "\u2026"
-                  }
-                ]
-              }
-            }
-          },
-          "400": {
-            "description": "Missing or invalid table parameter."
-          },
-          "500": {
-            "description": "Server error while querying the table."
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
       "get": {
         "tags": ["Search"],
-        "summary": "Return full or filtered table (GET alternative)",
-        "description": "Returns all records from the specified table or a filtered subset. Filters accept user-facing field names and values (mapping-aware).\n\nFilters use the repeatable `filter` query parameter with format `column:value` or `column:val1,val2` for multiple values. Values matching `true`/`false` are parsed as booleans; pure-digit strings as integers; everything else stays a string. Example: `?table=Court%20Decisions&filter=caseRank:10&filter=jurisdiction:Switzerland`.",
-        "operationId": "return_full_table_get_api_v1_search_full_table_get",
+        "summary": "Return full or filtered table",
+        "description": "Returns all records from the specified table or a filtered subset. Filters use the repeatable `filter` query parameter with format `column:value` or `column:val1,val2` for multiple values. Values matching `true`/`false` are parsed as booleans; pure-digit strings as integers; everything else stays a string. Example: `?table=Court%20Decisions&filter=caseRank:10&filter=jurisdiction:Switzerland`.",
+        "operationId": "return_full_table_api_v1_search_full_table_get",
         "parameters": [
           {
             "name": "table",
@@ -763,7 +463,7 @@
                       }
                     ]
                   },
-                  "title": "Response Return Full Table Get Api V1 Search Full Table Get"
+                  "title": "Response Return Full Table Api V1 Search Full Table Get"
                 },
                 "example": [
                   {
@@ -861,63 +561,9 @@
       }
     },
     "/ai/classify_query": {
-      "post": {
-        "tags": ["AI"],
-        "summary": "Classify a free-text user query into a predefined category",
-        "description": "Uses an external model to classify the user's query into one of the predefined CoLD categories.",
-        "operationId": "classify_query_api_v1_ai_classify_query_post",
-        "parameters": [
-          {
-            "name": "X-API-Key",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "title": "X-Api-Key"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ClassifyQueryRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Classification result",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string",
-                  "title": "Response Classify Query Api V1 Ai Classify Query Post"
-                },
-                "example": "Party autonomy (concept)"
-              }
-            }
-          },
-          "502": {
-            "description": "Upstream AI service error."
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
       "get": {
         "tags": ["AI"],
-        "summary": "Classify a free-text user query (GET alternative)",
+        "summary": "Classify a free-text user query into a predefined category",
         "description": "Uses an external model to classify the user's query into one of the predefined CoLD categories.",
         "operationId": "classify_query_get_api_v1_ai_classify_query_get",
         "parameters": [
@@ -5279,21 +4925,6 @@
         "type": "object",
         "title": "ArbitralRuleSearchResult"
       },
-      "ClassifyQueryRequest": {
-        "properties": {
-          "query": {
-            "type": "string"
-          }
-        },
-        "type": "object",
-        "required": ["query"],
-        "title": "ClassifyQueryRequest",
-        "examples": [
-          {
-            "query": "How do courts treat party autonomy?"
-          }
-        ]
-      },
       "ConfirmAnalysisRequest": {
         "properties": {
           "draftId": {
@@ -6526,25 +6157,6 @@
           "submitter_comments": "Spotted a typo in the abstract.",
           "submitter_email": "user@example.com"
         }
-      },
-      "CuratedDetailsRequest": {
-        "properties": {
-          "table": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string"
-          }
-        },
-        "type": "object",
-        "required": ["table", "id"],
-        "title": "CuratedDetailsRequest",
-        "examples": [
-          {
-            "id": "CHE_15-TC",
-            "table": "Answers"
-          }
-        ]
       },
       "DetailBase": {
         "properties": {
@@ -8312,45 +7924,6 @@
         ],
         "title": "EntityType"
       },
-      "FTFilterOption": {
-        "properties": {
-          "column": {
-            "type": "string"
-          },
-          "value": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "integer"
-              },
-              {
-                "type": "boolean"
-              },
-              {
-                "items": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "boolean"
-                    }
-                  ]
-                },
-                "type": "array"
-              }
-            ]
-          }
-        },
-        "type": "object",
-        "required": ["column", "value"],
-        "title": "FTFilterOption"
-      },
       "FTSFilterOption": {
         "properties": {
           "column": {
@@ -8560,184 +8133,6 @@
         "type": "object",
         "required": ["moderationStatus"],
         "title": "FeedbackUpdate"
-      },
-      "FullTableRequest": {
-        "properties": {
-          "table": {
-            "type": "string"
-          },
-          "filters": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/FTFilterOption"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "response_type": {
-            "anyOf": [
-              {
-                "type": "string",
-                "const": "parsed"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Response data format. Only 'parsed' is supported.",
-            "default": "parsed"
-          },
-          "limit": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "maximum": 10000.0,
-                "minimum": 1.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Maximum number of rows to return. Omit for no limit."
-          },
-          "order_by": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Column name to sort by (camelCase or snake_case). Unknown columns are ignored."
-          },
-          "order_dir": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": ["asc", "desc"]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Sort direction when order_by is provided.",
-            "default": "desc"
-          }
-        },
-        "type": "object",
-        "required": ["table"],
-        "title": "FullTableRequest",
-        "examples": [
-          {
-            "filters": [
-              {
-                "column": "Jurisdictions",
-                "value": "Switzerland"
-              }
-            ],
-            "limit": 10,
-            "order_by": "date",
-            "order_dir": "desc",
-            "response_type": "parsed",
-            "table": "Answers"
-          }
-        ]
-      },
-      "FullTextSearchRequest": {
-        "properties": {
-          "search_string": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "filters": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/FTSFilterOption"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "page": {
-            "type": "integer",
-            "minimum": 1.0,
-            "description": "Page number, must be >= 1",
-            "default": 1
-          },
-          "page_size": {
-            "type": "integer",
-            "maximum": 100.0,
-            "minimum": 1.0,
-            "description": "Number of results per page",
-            "default": 50
-          },
-          "sort_by_date": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Sort results by date descending if True.",
-            "default": false
-          },
-          "response_type": {
-            "anyOf": [
-              {
-                "type": "string",
-                "const": "parsed"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Response data format. Only 'parsed' is supported.",
-            "default": "parsed"
-          }
-        },
-        "type": "object",
-        "title": "FullTextSearchRequest",
-        "examples": [
-          {
-            "filters": [
-              {
-                "column": "tables",
-                "values": ["Answers", "Court Decisions"]
-              },
-              {
-                "column": "jurisdictions",
-                "values": ["Switzerland", "France"]
-              },
-              {
-                "column": "Themes",
-                "values": ["Party autonomy", "Freedom of choice"]
-              }
-            ],
-            "page": 1,
-            "page_size": 100,
-            "response_type": "parsed",
-            "search_string": "",
-            "sort_by_date": true
-          }
-        ]
       },
       "FullTextSearchResponse": {
         "properties": {


### PR DESCRIPTION
## Summary
- Removes POST variants of `/search/`, `/search/details`, `/search/full_table`, and `/ai/classify_query` (kept transitionally in #495 / #499 for backwards compatibility while the frontend migrated).
- Migrates the three remaining frontend pages still issuing direct POST fetches (`international-instrument/[...slug].vue`, `literature/new.vue`, `domestic-instrument/new.vue`) to the GET equivalents.
- With only one handler per route, the dual-mode helper indirection is inlined and unused request schemas (`FullTextSearchRequest`, `CuratedDetailsRequest`, `FullTableRequest`, `ClassifyQueryRequest`) are deleted.

## Test plan
- [x] `cd backend && make check` (212 passed, 2 skipped)
- [x] `cd frontend && pnpm run generate:api && pnpm run check` (156 tests pass; format/lint/typecheck clean)
- [ ] Manually exercise the three migrated forms once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)