### PR TITLE
feat(frontend): collapse long relations lists and show item count

### DIFF
--- a/frontend/app/components/entity/EntityContent.vue
+++ b/frontend/app/components/entity/EntityContent.vue
@@ -25,6 +25,9 @@
     <template v-for="section in resolvedRelations" :key="section.key">
       <section v-if="section.items.length > 0">
         <DetailRow :label="section.label" :variant="section.variant">
+          <template v-if="section.items.length > 1" #label-subtitle>
+            {{ section.items.length }} items
+          </template>
           <RelatedItemsList
             :items="section.items"
             :base-path="section.basePath"

--- a/frontend/app/components/ui/DetailRow.vue
+++ b/frontend/app/components/ui/DetailRow.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="detail-row @container" :class="variant ? `type-${variant}` : ''">
     <div class="flex flex-col gap-2 @md:flex-row @md:items-start @md:gap-10">
-      <div class="label-key @md:w-48 @md:shrink-0">
+      <div class="label-key flex flex-col items-start @md:w-48 @md:shrink-0">
         <span class="flex items-center gap-1.5">
           <span class="mono-font">
             {{ label }}
@@ -9,6 +9,9 @@
           <slot name="label-actions" />
           <InfoPopover v-if="tooltip" :text="tooltip" />
         </span>
+        <div v-if="$slots['label-subtitle']" class="label-subtitle">
+          <slot name="label-subtitle" />
+        </div>
       </div>
 
       <div class="detail-value w-full @md:flex-1">
@@ -106,5 +109,16 @@ defineProps({
 
 .label-key:hover :deep(svg) {
   color: var(--color-cold-night-alpha);
+}
+
+.label-subtitle {
+  display: block;
+  margin-top: 0.125rem;
+  font-size: 0.7rem;
+  font-weight: 400;
+  color: var(--color-cold-night-alpha);
+  text-transform: none;
+  letter-spacing: normal;
+  opacity: 0.6;
 }
 </style>

--- a/frontend/app/components/ui/RelatedItemsList.test.ts
+++ b/frontend/app/components/ui/RelatedItemsList.test.ts
@@ -32,26 +32,49 @@ describe("RelatedItemsList", () => {
     expect(wrapper.findComponent({ name: "LoadingBar" }).exists()).toBe(true);
   });
 
-  it("renders all items even when many", () => {
-    const manyItems = Array.from({ length: 15 }, (_, i) => ({
+  it("renders all items without ShowMoreLess when at or below threshold", () => {
+    const items = Array.from({ length: 20 }, (_, i) => ({
       id: `${i + 1}`,
       title: `Item ${i + 1}`,
     }));
 
     const wrapper = mount(RelatedItemsList, {
       props: {
-        items: manyItems,
+        items,
         basePath: "/test",
       },
     });
 
     expect(wrapper.text()).toContain("Item 1");
-    expect(wrapper.text()).toContain("Item 10");
-    expect(wrapper.text()).toContain("Item 11");
-    expect(wrapper.text()).toContain("Item 15");
+    expect(wrapper.text()).toContain("Item 20");
     expect(wrapper.findComponent({ name: "ShowMoreLess" }).exists()).toBe(
       false,
     );
+  });
+
+  it("collapses items above the threshold and expands via ShowMoreLess", async () => {
+    const items = Array.from({ length: 25 }, (_, i) => ({
+      id: `${i + 1}`,
+      title: `Item ${i + 1}`,
+    }));
+
+    const wrapper = mount(RelatedItemsList, {
+      props: {
+        items,
+        basePath: "/test",
+      },
+    });
+
+    expect(wrapper.text()).toContain("Item 20");
+    expect(wrapper.text()).not.toContain("Item 21");
+    expect(wrapper.text()).not.toContain("Item 25");
+
+    const toggle = wrapper.findComponent({ name: "ShowMoreLess" });
+    expect(toggle.exists()).toBe(true);
+
+    await toggle.vm.$emit("update:isExpanded", true);
+    expect(wrapper.text()).toContain("Item 21");
+    expect(wrapper.text()).toContain("Item 25");
   });
 
   it("constructs correct link paths with basePath", () => {

--- a/frontend/app/components/ui/RelatedItemsList.vue
+++ b/frontend/app/components/ui/RelatedItemsList.vue
@@ -7,7 +7,7 @@
     <div v-else-if="items.length" class="result-value-small">
       <div class="mb-2 flex flex-row flex-wrap gap-x-6 gap-y-2">
         <EntityLink
-          v-for="item in items"
+          v-for="item in visibleItems"
           :key="item.id"
           :id="item.id"
           :title="item.title"
@@ -15,6 +15,10 @@
           :badge="item.badge"
         />
       </div>
+      <ShowMoreLess
+        v-if="items.length > SHOW_MORE_THRESHOLD"
+        v-model:is-expanded="isExpanded"
+      />
     </div>
     <p
       v-else-if="emptyValueBehavior.action === 'display'"
@@ -26,11 +30,14 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import LoadingBar from "@/components/layout/LoadingBar.vue";
 import InlineError from "@/components/ui/InlineError.vue";
 import EntityLink from "@/components/ui/EntityLink.vue";
+import ShowMoreLess from "@/components/ui/ShowMoreLess.vue";
 import type { RelatedItem, EmptyValueBehavior } from "@/types/ui";
+
+const SHOW_MORE_THRESHOLD = 20;
 
 const props = withDefaults(
   defineProps<{
@@ -50,7 +57,15 @@ const props = withDefaults(
   },
 );
 
+const isExpanded = ref(false);
+
 const hasItems = computed(() => props.items.length > 0);
+
+const visibleItems = computed(() =>
+  isExpanded.value || props.items.length <= SHOW_MORE_THRESHOLD
+    ? props.items
+    : props.items.slice(0, SHOW_MORE_THRESHOLD),
+);
 
 const shouldShowSection = computed(
   () =>


### PR DESCRIPTION
## Summary
- Restored Show More/Less toggle on relation lists past 20 items (`RelatedItemsList.vue`).
- Added an item count subtitle under the detail row label, rendered as a stacked second line via a new `label-subtitle` slot on `DetailRow.vue`.

## Test plan
- [x] `pnpm run check` (format, lint, typecheck, vitest)
- [ ] Visual check on an entity page with >20 relations to confirm collapse/expand and subtitle layout