### PR TITLE
fix(auth): recover from callback errors and hydrate useUser past CDN cache

### DIFF
--- a/frontend/app/error.vue
+++ b/frontend/app/error.vue
@@ -6,11 +6,19 @@
       <div
         class="max-w-container mx-auto flex min-h-[50vh] w-full flex-col items-center justify-center text-center"
       >
-        <h2>{{ errorMessage }}</h2>
+        <h2>{{ heading }}</h2>
+        <p v-if="detail" class="text-cold-night-alpha mt-2 text-sm">
+          {{ detail }}
+        </p>
 
-        <NuxtLink to="/" class="text-cold-teal mt-6">
-          Take me back to Home
-        </NuxtLink>
+        <div class="mt-6 flex flex-col items-center gap-3">
+          <a v-if="isAuthFailure" href="/auth/login" class="text-cold-teal">
+            Try logging in again
+          </a>
+          <NuxtLink to="/" class="text-cold-teal">
+            Take me back to Home
+          </NuxtLink>
+        </div>
       </div>
     </main>
 
@@ -19,12 +27,37 @@
 </template>
 
 <script setup lang="ts">
+import type { NuxtError } from "#app";
+import { computed } from "vue";
+import { useRoute } from "vue-router";
 import Nav from "@/components/layout/Nav.vue";
 import Footer from "@/components/layout/Footer.vue";
-import { useRoute } from "vue-router";
 
+const props = defineProps<{ error: NuxtError }>();
 const route = useRoute();
-const errorMessage = String(
-  route.query.message || "Sorry, we can’t find the page you’re looking for.",
-);
+
+const isAuthFailure = computed(() => route.path?.startsWith("/auth/") ?? false);
+
+const heading = computed(() => {
+  const code = props.error?.statusCode;
+  if (code === 404) {
+    return "Sorry, we can’t find the page you’re looking for.";
+  }
+  if (isAuthFailure.value) {
+    return "We couldn’t complete your sign-in.";
+  }
+  return "Something went wrong.";
+});
+
+const detail = computed(() => {
+  const code = props.error?.statusCode;
+  const status = props.error?.statusMessage;
+  const message = props.error?.message;
+  const parts = [
+    code ? String(code) : null,
+    status && status !== "Server Error" ? status : null,
+    message && message !== status ? message : null,
+  ].filter(Boolean);
+  return parts.length > 0 ? parts.join(" — ") : null;
+});
 </script>

--- a/frontend/app/plugins/auth-hydrate.client.ts
+++ b/frontend/app/plugins/auth-hydrate.client.ts
@@ -1,0 +1,11 @@
+import { defineNuxtPlugin } from "#imports";
+
+export default defineNuxtPlugin(async () => {
+  const user = useUser();
+  if (user.value) return;
+  try {
+    user.value = (await $fetch("/api/auth/me")) ?? undefined;
+  } catch {
+    user.value = undefined;
+  }
+});

--- a/frontend/server/api/auth/me.get.ts
+++ b/frontend/server/api/auth/me.get.ts
@@ -1,0 +1,7 @@
+import { defineEventHandler, setResponseHeader } from "h3";
+
+export default defineEventHandler(async (event) => {
+  setResponseHeader(event, "Cache-Control", "no-store, private");
+  const auth0Client = useAuth0(event);
+  return await auth0Client.getUser();
+});

--- a/frontend/server/routes/auth/callback.get.ts
+++ b/frontend/server/routes/auth/callback.get.ts
@@ -1,0 +1,38 @@
+import { defineEventHandler, sendRedirect } from "h3";
+import * as logfire from "@pydantic/logfire-node";
+
+export default defineEventHandler(async (event) => {
+  const auth0Client = useAuth0(event);
+  const auth0ClientOptions = event.context.auth0ClientOptions;
+
+  try {
+    const { appState } = await auth0Client.completeInteractiveLogin<
+      { returnTo?: string } | undefined
+    >(new URL(event.node.req.url as string, auth0ClientOptions.appBaseUrl));
+
+    const target = toSameOriginRedirect(
+      appState?.returnTo,
+      auth0ClientOptions.appBaseUrl,
+    );
+    return sendRedirect(event, target);
+  } catch (error) {
+    logfire.warning("Auth0 callback failed; restarting login", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return sendRedirect(event, "/auth/login");
+  }
+});
+
+function toSameOriginRedirect(
+  candidate: string | undefined,
+  baseUrl: string,
+): string {
+  if (!candidate) return baseUrl;
+  try {
+    const target = new URL(candidate, baseUrl);
+    const base = new URL(baseUrl);
+    return target.origin === base.origin ? target.toString() : baseUrl;
+  } catch {
+    return baseUrl;
+  }
+}


### PR DESCRIPTION
## Summary

- `/auth/callback` is now overridden by a custom Nitro route that catches `completeInteractiveLogin` failures (missing `__a0_tx`, reused code, state mismatch) and 302s back to `/auth/login` to start a fresh transaction, instead of dropping users on a generic 500 page.
- Adds `/api/auth/me` (`Cache-Control: no-store`) plus a client plugin that hydrates `useUser()` on first load — needed because Cloudflare cache-HITs `/`, so the SSR'd anonymous payload was leaking into logged-in sessions and breaking the Footer Login/Logout toggle and any auth-gated middleware (`auth.ts`, `moderation.ts`).
- Replaces `error.vue`'s hard-coded "Sorry, we can't find the page" message with the real `statusCode`/`statusMessage`, plus a "Try logging in again" link on `/auth/*` failures.
- The `www.cold.global` → `cold.global` canonical redirect was implemented at the Cloudflare edge (Redirect Rule), not in this branch.

## Test plan

- [ ] Sign in from an incognito window → lands on home with footer showing Logout
- [ ] Sign in from a tab that was already on `/` (cache HIT) → footer flips to Logout once `/api/auth/me` resolves
- [ ] Force a callback failure (visit `/auth/callback?code=fake`) → bounces through `/auth/login` instead of showing the error page
- [ ] Hit any non-existent path → still shows 404 message; hit any other 5xx → shows actual status code

🤖 Generated with [Claude Code](https://claude.com/claude-code)