### PR TITLE
feat(frontend): search filter schips, footer meta strip, submission disclaimer

### DIFF
--- a/frontend/app/assets/styles.css
+++ b/frontend/app/assets/styles.css
@@ -1779,6 +1779,154 @@ button.cold-toggle-btn[aria-pressed="true"] {
   text-decoration-color: var(--color-cold-night);
 }
 
+/* Search/filter chip ("schip") - shared monospace pill chip used across
+   MetaBand, SearchResultsHeader, EntityListFilters, etc. Recolor by setting
+   --schip-color on the element or via a .schip--type.label-* modifier. */
+.schip {
+  --schip-color: var(--color-cold-purple);
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 2px 9px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--schip-color) 8%, white);
+  color: color-mix(in srgb, var(--schip-color) 80%, black);
+  text-decoration: none;
+  white-space: nowrap;
+  border: 1px solid transparent;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.schip:not(.schip--static):hover {
+  background: color-mix(in srgb, var(--schip-color) 14%, white);
+  border-color: color-mix(in srgb, var(--schip-color) 30%, white);
+  color: color-mix(in srgb, var(--schip-color) 95%, black);
+}
+
+.schip--static {
+  cursor: default;
+}
+
+.schip--button {
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.schip--theme {
+  --schip-color: var(--color-cold-purple);
+}
+
+.schip--type {
+  --schip-color: var(--color-cold-purple);
+}
+
+.schip--type.label-court-decision {
+  --schip-color: var(--color-label-court-decision);
+}
+.schip--type.label-question {
+  --schip-color: var(--color-label-question);
+}
+.schip--type.label-instrument {
+  --schip-color: var(--color-label-instrument);
+}
+.schip--type.label-arbitration {
+  --schip-color: var(--color-label-arbitration);
+}
+.schip--type.label-literature {
+  --schip-color: var(--color-label-literature);
+}
+.schip--type.label-specialist {
+  --schip-color: var(--color-label-specialist);
+}
+.schip--type.label-jurisdiction {
+  --schip-color: var(--color-cold-night);
+}
+
+.schip--jur {
+  --schip-color: var(--color-cold-night);
+}
+
+/* Flag/arrow swap on hover for jurisdiction chips */
+.schip-flag-wrap,
+.schip-arrow-wrap {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 16px;
+  height: 11px;
+  overflow: hidden;
+  transition:
+    width 0.18s ease,
+    opacity 0.15s ease;
+}
+
+.schip-flag {
+  width: 16px;
+  height: 11px;
+  object-fit: contain;
+}
+
+.schip-arrow-wrap {
+  width: 0;
+  opacity: 0;
+  font-size: 12px;
+}
+
+.schip--jur:hover .schip-flag-wrap {
+  width: 0;
+  opacity: 0;
+}
+
+.schip--jur:hover .schip-arrow-wrap {
+  width: 16px;
+  opacity: 0.9;
+}
+
+/* Tag/affordance icon swap (bookmark → search) for interactive chips */
+.schip-tag,
+.schip-affordance {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 11px;
+  font-size: 11px;
+  overflow: hidden;
+  transition:
+    width 0.15s ease,
+    opacity 0.15s ease;
+}
+
+.schip-tag {
+  opacity: 0.65;
+}
+
+.schip-affordance {
+  width: 0;
+  opacity: 0;
+}
+
+.schip:not(.schip--static):hover .schip-tag {
+  width: 0;
+  opacity: 0;
+}
+
+.schip:not(.schip--static):hover .schip-affordance {
+  width: 11px;
+  opacity: 0.9;
+}
+
 /* Navigation tabs - unified style for region badges and section navigation */
 .nav-tab {
   cursor: pointer;

--- a/frontend/app/components/entity-list/EntityListFilters.vue
+++ b/frontend/app/components/entity-list/EntityListFilters.vue
@@ -1,34 +1,37 @@
 <template>
-  <div class="entity-filters">
+  <div
+    class="entity-filters"
+    :class="{ 'entity-filters--loading': props.loading }"
+    :aria-busy="props.loading || undefined"
+  >
     <div
       v-if="props.filters.includes('jurisdiction')"
       class="entity-filters__control"
     >
-      <label class="entity-filters__label">Jurisdiction</label>
       <JurisdictionSelectMenu
         v-if="jurisdictions"
         :jurisdictions="jurisdictions"
         :model-value="jurisdiction"
-        placeholder="Any"
+        placeholder="Jurisdiction"
         @update:model-value="jurisdiction = $event"
       />
     </div>
 
     <div v-if="props.filters.includes('theme')" class="entity-filters__control">
-      <label class="entity-filters__label">Theme</label>
       <USelectMenu
         v-model="theme"
         :items="themeOptions"
-        placeholder="Any"
+        placeholder="Theme"
         size="xl"
         class="w-56"
         :ui="{
-          content: 'max-h-none w-max min-w-(--reka-combobox-trigger-width)',
+          content:
+            'max-h-(--reka-combobox-content-available-height) w-max min-w-(--reka-combobox-trigger-width)',
           item: 'data-highlighted:bg-transparent',
         }"
       >
         <template #item-label="{ item }">
-          <span class="schip schip--theme">
+          <span class="schip schip--theme schip--static">
             <span class="schip-tag" aria-hidden="true">
               <UIcon name="i-lucide:bookmark" />
             </span>
@@ -39,7 +42,26 @@
     </div>
 
     <div v-if="hasActiveFilter" class="entity-filters__reset">
-      <UButton variant="ghost" size="sm" :icon="ICON_CLEAR" @click="reset">
+      <span
+        v-if="props.loading"
+        class="entity-filters__status"
+        role="status"
+        aria-live="polite"
+      >
+        <span class="entity-filters__pulse" aria-hidden="true" />
+        Updating
+      </span>
+      <span v-else-if="formattedCount" class="entity-filters__count">
+        {{ formattedCount }} {{ count === 1 ? "result" : "results" }}
+      </span>
+      <UButton
+        variant="ghost"
+        size="sm"
+        :leading-icon="ICON_CLEAR"
+        :trailing-icon="ICON_CLEAR"
+        :disabled="props.loading"
+        @click="reset"
+      >
         Clear filters
       </UButton>
     </div>
@@ -59,6 +81,8 @@ const ICON_CLEAR = "i-material-symbols:close";
 
 const props = defineProps<{
   filters: EntityListFilterKey[];
+  count?: number;
+  loading?: boolean;
 }>();
 
 const jurisdiction = defineModel<JurisdictionOption | undefined>(
@@ -73,6 +97,12 @@ const { data: jurisdictions } = useJurisdictions(wantsJurisdiction);
 
 const hasActiveFilter = computed(
   () => Boolean(jurisdiction.value?.coldId) || Boolean(theme.value),
+);
+
+const formattedCount = computed(() =>
+  typeof props.count === "number"
+    ? props.count.toString().replace(/\B(?=(\d{3})+(?!\d))/g, "'")
+    : "",
 );
 
 const reset = () => {
@@ -91,52 +121,71 @@ const reset = () => {
 
 .entity-filters__control {
   min-width: 14rem;
+  transition: opacity 200ms ease;
 }
 
-.entity-filters__label {
-  display: block;
-  font-weight: 700;
-  font-size: 11px;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--color-cold-night-alpha);
-  margin-bottom: 4px;
+.entity-filters--loading .entity-filters__control {
+  opacity: 0.55;
+  pointer-events: none;
 }
 
 .entity-filters__reset {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
+  gap: 0.5rem;
 }
 
-.schip {
-  --schip-color: var(--color-cold-purple);
+.entity-filters__count {
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: var(--color-cold-night-alpha);
+}
+
+.entity-filters__status {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: 0.5rem;
   font-family: "IBM Plex Mono", monospace;
   font-size: 11px;
   font-weight: 600;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  padding: 2px 9px;
+  color: var(--color-cold-night-alpha);
+}
+
+.entity-filters__pulse {
+  width: 6px;
+  height: 6px;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--schip-color) 8%, white);
-  color: color-mix(in srgb, var(--schip-color) 80%, black);
-  white-space: nowrap;
-  border: 1px solid transparent;
+  background: var(--color-cold-purple);
+  animation: entity-filters-pulse 1.1s ease-in-out infinite;
+  box-shadow: 0 0 0 0
+    color-mix(in srgb, var(--color-cold-purple) 30%, transparent);
 }
 
-.schip--theme {
-  --schip-color: var(--color-cold-purple);
+@keyframes entity-filters-pulse {
+  0%,
+  100% {
+    transform: scale(0.55);
+    opacity: 0.45;
+    box-shadow: 0 0 0 0
+      color-mix(in srgb, var(--color-cold-purple) 30%, transparent);
+  }
+  50% {
+    transform: scale(1);
+    opacity: 1;
+    box-shadow: 0 0 0 4px
+      color-mix(in srgb, var(--color-cold-purple) 0%, transparent);
+  }
 }
 
-.schip-tag {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  width: 11px;
-  font-size: 11px;
-  opacity: 0.65;
+@media (prefers-reduced-motion: reduce) {
+  .entity-filters__control {
+    transition: none;
+  }
+  .entity-filters__pulse {
+    animation: none;
+    opacity: 0.85;
+  }
 }
 </style>

--- a/frontend/app/components/entity-list/EntityListTable.vue
+++ b/frontend/app/components/entity-list/EntityListTable.vue
@@ -1,61 +1,72 @@
 <template>
   <div class="w-full">
     <div
-      :class="[
-        'border-cold-gray relative border-y transition-opacity duration-150',
-        props.loading && 'pointer-events-none opacity-50',
-      ]"
+      class="entity-list-table border-cold-gray relative border-y"
+      :class="{ 'entity-list-table--loading': props.loading }"
       :style="widthVars"
+      :aria-busy="props.loading || undefined"
     >
-      <UTable :columns="utableColumns" :data="props.rows" :ui="utableUi">
-        <template
-          v-for="col in props.columns"
-          #[`${col.key}-cell`]="{ row }"
-          :key="col.key"
-        >
-          <component
-            :is="row.original.coldId ? 'a' : 'span'"
-            :href="
-              row.original.coldId ? rowHref(row.original.coldId) : undefined
-            "
-            class="table-row-link"
-            :class="row.original.coldId ? '' : 'text-gray-400'"
-            @click="
-              row.original.coldId && handleRowClick($event, row.original.coldId)
-            "
+      <div
+        v-if="props.loading"
+        class="entity-list-table__progress"
+        aria-hidden="true"
+      >
+        <span class="entity-list-table__progress-shuttle" />
+      </div>
+      <div class="entity-list-table__body">
+        <UTable :columns="utableColumns" :data="props.rows" :ui="utableUi">
+          <template
+            v-for="col in props.columns"
+            #[`${col.key}-cell`]="{ row }"
+            :key="col.key"
           >
-            <slot :name="`cell-${col.key}`" :row="row.original" :column="col">
-              <span
-                class="text-cold-night block overflow-hidden text-sm font-medium text-ellipsis whitespace-nowrap"
-              >
-                {{ row.original[col.key] || "—" }}
-              </span>
-            </slot>
-          </component>
-        </template>
+            <component
+              :is="row.original.coldId ? 'a' : 'span'"
+              :href="
+                row.original.coldId ? rowHref(row.original.coldId) : undefined
+              "
+              class="table-row-link"
+              :class="row.original.coldId ? '' : 'text-gray-400'"
+              @click="
+                row.original.coldId &&
+                handleRowClick($event, row.original.coldId)
+              "
+            >
+              <slot :name="`cell-${col.key}`" :row="row.original" :column="col">
+                <span
+                  class="text-cold-night block overflow-hidden text-sm font-medium text-ellipsis whitespace-nowrap"
+                >
+                  {{ row.original[col.key] || "—" }}
+                </span>
+              </slot>
+            </component>
+          </template>
 
-        <template #open-cell="{ row }">
-          <a
-            v-if="row.original.coldId"
-            :href="rowHref(row.original.coldId)"
-            class="table-row-link flex h-full items-center justify-end pr-1"
-            aria-label="Open"
-            @click="handleRowClick($event, row.original.coldId)"
-          >
-            <UIcon
-              :name="ICON_OPEN"
-              class="text-cold-night-alpha group-hover/row:text-cold-purple text-xl transition-colors group-hover/row:animate-[bounce-right_0.4s_ease-out]"
-            />
-          </a>
-          <span v-else class="text-gray-400">—</span>
-        </template>
+          <template #open-cell="{ row }">
+            <a
+              v-if="row.original.coldId"
+              :href="rowHref(row.original.coldId)"
+              class="table-row-link flex h-full items-center justify-end pr-1"
+              aria-label="Open"
+              @click="handleRowClick($event, row.original.coldId)"
+            >
+              <UIcon
+                :name="ICON_OPEN"
+                class="text-cold-night-alpha group-hover/row:text-cold-purple text-xl transition-colors group-hover/row:animate-[bounce-right_0.4s_ease-out]"
+              />
+            </a>
+            <span v-else class="text-gray-400">—</span>
+          </template>
 
-        <template #empty>
-          <span v-if="!props.loading">
-            {{ props.emptyMessage ?? "No results match the selected filters." }}
-          </span>
-        </template>
-      </UTable>
+          <template #empty>
+            <span v-if="!props.loading">
+              {{
+                props.emptyMessage ?? "No results match the selected filters."
+              }}
+            </span>
+          </template>
+        </UTable>
+      </div>
     </div>
 
     <EntityListPagination
@@ -212,3 +223,66 @@ const widthVars = computed<CSSProperties>(() => {
   return vars as CSSProperties;
 });
 </script>
+
+<style scoped>
+.entity-list-table--loading {
+  cursor: progress;
+}
+
+.entity-list-table__body {
+  transition: opacity 220ms ease;
+}
+
+.entity-list-table--loading .entity-list-table__body {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.entity-list-table__progress {
+  position: absolute;
+  top: -1px;
+  left: 0;
+  right: 0;
+  height: 1.5px;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 2;
+  background: color-mix(in srgb, var(--color-cold-purple) 8%, transparent);
+}
+
+.entity-list-table__progress-shuttle {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    color-mix(in srgb, var(--color-cold-purple) 70%, white) 40%,
+    var(--color-cold-purple) 50%,
+    var(--color-cold-green) 58%,
+    transparent 100%
+  );
+  animation: entity-list-table-shuttle 1.3s cubic-bezier(0.45, 0, 0.55, 1)
+    infinite;
+  transform: translateX(-100%);
+}
+
+@keyframes entity-list-table-shuttle {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .entity-list-table__body {
+    transition: none;
+  }
+  .entity-list-table__progress-shuttle {
+    animation: none;
+    transform: none;
+    background: color-mix(in srgb, var(--color-cold-purple) 50%, transparent);
+  }
+}
+</style>

--- a/frontend/app/components/jurisdiction/JurisdictionSelectMenu.vue
+++ b/frontend/app/components/jurisdiction/JurisdictionSelectMenu.vue
@@ -6,7 +6,6 @@
     :placeholder="placeholder"
     :items="selectItems"
     :disabled="disabled"
-    :leading="!!internalSelected?.original?.coldId"
     size="xl"
     :ui="{
       content:
@@ -14,7 +13,6 @@
     }"
     @update:model-value="onInternalSelect"
   >
-    <!-- Custom item rendering with avatars -->
     <template #item="{ item }">
       <div class="flex items-center">
         <JurisdictionFlag
@@ -33,13 +31,21 @@
       </div>
     </template>
 
-    <template #leading>
-      <JurisdictionFlag
+    <template #default>
+      <span
         v-if="internalSelected?.original?.coldId"
-        :iso3="internalSelected.original.coldId"
-        :faded="!hasCoverage(internalSelected.original.answerCoverage)"
-        class="mr-1.5"
-      />
+        class="flex w-full items-center overflow-hidden whitespace-nowrap"
+      >
+        <JurisdictionFlag
+          :iso3="internalSelected.original.coldId"
+          :faded="!hasCoverage(internalSelected.original.answerCoverage)"
+          class="mr-1.5"
+        />
+        <span class="truncate">{{ internalSelected.label }}</span>
+      </span>
+      <span v-else class="truncate text-(--ui-text-muted)">
+        {{ placeholder }}
+      </span>
     </template>
   </USelectMenu>
 </template>

--- a/frontend/app/components/layout/Footer.vue
+++ b/frontend/app/components/layout/Footer.vue
@@ -1,7 +1,34 @@
 <script setup lang="ts">
 import { aboutNavLinks, learnNavLinks } from "@/config/navigation";
+import { externalLinks } from "@/utils/externalLinks";
 
 const user = useUser();
+
+interface SocialLink {
+  label: string;
+  icon: string;
+  href: string;
+}
+
+const socials: SocialLink[] = [
+  {
+    label: "Subscribe to the CoLD Newsletter on Substack",
+    icon: "i-simple-icons:substack",
+    href: externalLinks.substack,
+  },
+  {
+    label: "Follow CoLD on LinkedIn",
+    icon: "i-simple-icons:linkedin",
+    href: externalLinks.linkedin,
+  },
+  {
+    label: "Browse the CoLD source code on GitHub",
+    icon: "i-simple-icons:github",
+    href: externalLinks.github,
+  },
+];
+
+const currentYear = new Date().getFullYear();
 </script>
 
 <template>
@@ -31,9 +58,8 @@ const user = useUser();
         </p>
       </div>
 
-      <!-- Footer Sitemap - 3 Columns -->
-      <div class="footer-border grid grid-cols-1 gap-8 pt-8 md:grid-cols-3">
-        <!-- Column 1: About with subpages -->
+      <!-- Footer Sitemap - 4 Columns -->
+      <div class="footer-border grid grid-cols-1 gap-8 pt-8 md:grid-cols-4">
         <div class="flex flex-row justify-between gap-3 md:flex-col">
           <h3 class="footer-heading mb-2">About</h3>
           <div class="flex flex-col gap-3 text-right md:text-left">
@@ -48,7 +74,6 @@ const user = useUser();
           </div>
         </div>
 
-        <!-- Column 2: Learn with subpages -->
         <div class="flex flex-row justify-between gap-3 md:flex-col">
           <h3 class="footer-heading mb-2">Learn</h3>
           <div class="flex flex-col gap-3 text-right md:text-left">
@@ -63,7 +88,6 @@ const user = useUser();
           </div>
         </div>
 
-        <!-- Column 3: Utilities -->
         <div
           class="flex flex-row justify-between gap-3 md:flex-col md:justify-start"
         >
@@ -76,10 +100,11 @@ const user = useUser();
             </NuxtLink>
           </div>
         </div>
+
         <div
           class="flex flex-row justify-between gap-3 md:flex-col md:justify-start"
         >
-          <h3 class="footer-heading my-2">Admin</h3>
+          <h3 class="footer-heading mb-2">Admin</h3>
           <div class="flex flex-col gap-3 text-right md:text-left">
             <ClientOnly>
               <a
@@ -106,6 +131,162 @@ const user = useUser();
           </div>
         </div>
       </div>
+
+      <!-- Bottom meta strip: Cite & License · Funding · Stay Connected -->
+      <div class="footer-border footer-meta mt-10 pt-8">
+        <div class="footer-meta__grid">
+          <div class="footer-meta__col">
+            <h3 class="footer-heading mb-3">Cite &amp; License</h3>
+            <p class="footer-meta__line">
+              Cite as
+              <span class="footer-meta__muted">
+                Choice of Law Dataverse ({{ currentYear }}).
+              </span>
+            </p>
+            <p class="footer-meta__line">
+              Released under
+              <a
+                href="https://creativecommons.org/licenses/by-sa/4.0/"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="footer-meta__link"
+              >
+                CC&nbsp;BY-SA&nbsp;4.0
+              </a>
+            </p>
+            <NuxtLink to="/disclaimer" class="footer-meta__link">
+              Citation &amp; data terms →
+            </NuxtLink>
+          </div>
+
+          <div class="footer-meta__col">
+            <h3 class="footer-heading mb-3">Funding &amp; Host</h3>
+            <p class="footer-meta__line">
+              Swiss National Science Foundation
+              <span class="footer-meta__muted">
+                Project No.&nbsp;215469 · 2023–2026
+              </span>
+            </p>
+            <p class="footer-meta__line">University of Lucerne</p>
+            <NuxtLink to="/about/supporters" class="footer-meta__link">
+              All supporters →
+            </NuxtLink>
+          </div>
+
+          <div class="footer-meta__col">
+            <h3 class="footer-heading mb-3">Stay Connected</h3>
+            <div class="footer-socials">
+              <a
+                v-for="social in socials"
+                :key="social.label"
+                :href="social.href"
+                target="_blank"
+                rel="noopener noreferrer"
+                :aria-label="social.label"
+                class="footer-social"
+              >
+                <Icon :name="social.icon" class="footer-social__icon" />
+              </a>
+            </div>
+            <NuxtLink to="/contact" class="footer-meta__link">
+              Contact the team →
+            </NuxtLink>
+          </div>
+        </div>
+      </div>
     </div>
   </footer>
 </template>
+
+<style scoped>
+.footer-meta__grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+}
+
+@media (min-width: 768px) {
+  .footer-meta__grid {
+    grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr) minmax(0, 0.9fr);
+    gap: 2.5rem;
+  }
+}
+
+.footer-meta__col {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.footer-meta__line {
+  font-size: 0.8125rem;
+  line-height: 1.55;
+  color: color-mix(in srgb, white 88%, transparent);
+}
+
+.footer-meta__muted {
+  display: block;
+  color: color-mix(in srgb, white 60%, transparent);
+  font-size: 0.75rem;
+  margin-top: 0.125rem;
+}
+
+.footer-meta__link {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: white;
+  text-decoration: none;
+  border-bottom: 1px solid color-mix(in srgb, white 30%, transparent);
+  align-self: flex-start;
+  padding-bottom: 1px;
+  transition:
+    color 150ms ease,
+    border-color 150ms ease;
+}
+
+.footer-meta__link:hover {
+  color: var(--color-cold-green);
+  border-color: var(--color-cold-green);
+}
+
+.footer-socials {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.125rem;
+}
+
+.footer-social {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 0.625rem;
+  background: color-mix(in srgb, white 6%, transparent);
+  border: 1px solid color-mix(in srgb, white 12%, transparent);
+  color: color-mix(in srgb, white 85%, transparent);
+  transition:
+    background 180ms ease,
+    border-color 180ms ease,
+    color 180ms ease,
+    transform 180ms ease;
+}
+
+.footer-social:hover {
+  background: color-mix(in srgb, white 12%, transparent);
+  border-color: color-mix(in srgb, var(--color-cold-green) 55%, transparent);
+  color: var(--color-cold-green);
+  transform: translateY(-1px);
+}
+
+.footer-social__icon {
+  font-size: 1rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .footer-social:hover {
+    transform: none;
+  }
+}
+</style>

--- a/frontend/app/components/search-results/SearchResultsHeader.vue
+++ b/frontend/app/components/search-results/SearchResultsHeader.vue
@@ -1,46 +1,88 @@
 <template>
-  <div class="filters-header mt-[-24px] !mb-2 ml-[-1px] flex flex-col gap-4">
-    <div class="flex w-full flex-col flex-wrap gap-5 sm:flex-row">
-      <SearchFilters
-        :model-value="currentJurisdictionFilter"
-        :options="jurisdictions || []"
-        class="w-full flex-shrink-0 lg:w-60"
-        :show-avatars="true"
-        :multiple="false"
-        :highlight-jurisdictions="true"
-        :placeholder="'Jurisdiction'"
-        @update:model-value="currentJurisdictionFilter = $event"
-      />
-      <SearchFilters
-        :model-value="currentThemeFilter"
-        :options="themeOptions"
-        class="w-full flex-shrink-0 lg:w-60"
-        :placeholder="'Themes'"
-        :searchable="false"
-        @update:model-value="currentThemeFilter = $event"
-      />
-      <SearchFilters
-        :model-value="currentTypeFilter"
-        :options="typeOptions"
-        class="w-full flex-shrink-0 lg:w-60"
-        :multiple="false"
-        :placeholder="'Types'"
-        :searchable="false"
-        @update:model-value="currentTypeFilter = $event"
-      />
-      <UButton
-        v-if="hasActiveFilters"
-        variant="link"
-        class="w-full sm:w-auto"
-        @click="resetFilters"
-      >
-        Reset
-      </UButton>
+  <div class="search-results-header">
+    <div class="entity-filters">
+      <div class="entity-filters__control">
+        <JurisdictionSelectMenu
+          v-if="jurisdictions"
+          :jurisdictions="jurisdictions"
+          :model-value="jurisdictionOption"
+          placeholder="Jurisdiction"
+          @update:model-value="onJurisdictionChange"
+        />
+      </div>
+
+      <div class="entity-filters__control">
+        <USelectMenu
+          v-model="themeValues"
+          multiple
+          :items="themeOptions"
+          placeholder="Theme"
+          size="xl"
+          class="w-56"
+          :ui="{
+            content:
+              'max-h-(--reka-combobox-content-available-height) w-max min-w-(--reka-combobox-trigger-width)',
+            item: 'data-highlighted:bg-transparent',
+          }"
+        >
+          <template #item-label="{ item }">
+            <span class="schip schip--theme schip--static">
+              <span class="schip-tag" aria-hidden="true">
+                <UIcon name="i-lucide:bookmark" />
+              </span>
+              <span class="schip-text">{{ item }}</span>
+            </span>
+          </template>
+        </USelectMenu>
+      </div>
+
+      <div class="entity-filters__control">
+        <USelectMenu
+          v-model="typeValues"
+          multiple
+          :items="typeOptions"
+          placeholder="Type"
+          size="xl"
+          class="w-56"
+          :ui="{
+            content:
+              'max-h-(--reka-combobox-content-available-height) w-max min-w-(--reka-combobox-trigger-width)',
+            item: 'data-highlighted:bg-transparent',
+          }"
+        >
+          <template #item-label="{ item }">
+            <span
+              :class="[
+                'schip',
+                'schip--type',
+                'schip--static',
+                getLabelColorClass(item),
+              ]"
+            >
+              <span class="schip-tag" aria-hidden="true">
+                <UIcon name="i-lucide:tag" />
+              </span>
+              <span class="schip-text">{{ item }}</span>
+            </span>
+          </template>
+        </USelectMenu>
+      </div>
+
+      <div v-if="hasActiveFilters" class="entity-filters__reset">
+        <UButton
+          variant="ghost"
+          size="sm"
+          :icon="ICON_CLEAR"
+          @click="resetFilters"
+        >
+          Clear filters
+        </UButton>
+      </div>
     </div>
 
     <div
       v-if="props.hasQuery || hasActiveFilters"
-      class="result-value-small results-margin-fix flex w-full items-center gap-2 whitespace-nowrap"
+      class="result-value-small flex w-full items-center gap-2 whitespace-nowrap"
     >
       <template v-if="!props.loading">
         <template v-if="props.totalMatches > 1">
@@ -94,10 +136,21 @@ import { useRoute, useRouter } from "vue-router";
 import { useSearchFilters } from "@/composables/useSearchFilters";
 import importedThemeOptions from "@/assets/themeOptions.json";
 import importedTypeOptions from "@/assets/typeOptions.json";
-import SearchFilters from "@/components/search-results/SearchFilters.vue";
-import { useJurisdictions } from "@/composables/useJurisdictions";
+import JurisdictionSelectMenu from "@/components/jurisdiction/JurisdictionSelectMenu.vue";
+import {
+  useJurisdictions,
+  useJurisdictionLookup,
+} from "@/composables/useJurisdictions";
 import { useScreenAnnouncer } from "@/composables/useScreenAnnouncer";
-import type { SearchFilters as SearchFiltersType } from "@/types/api";
+import { getLabelColorClass } from "@/config/entityRegistry";
+import type {
+  FilterObjectOption,
+  FilterOption,
+  SearchFilters as SearchFiltersType,
+} from "@/types/api";
+import type { JurisdictionOption } from "@/types/analyzer";
+
+const ICON_CLEAR = "i-material-symbols:close";
 
 const props = withDefaults(
   defineProps<{
@@ -145,7 +198,48 @@ const resultLabel = computed(() =>
 );
 
 const { data: jurisdictions } = useJurisdictions();
+const { findJurisdictionByName } = useJurisdictionLookup();
 const { announce } = useScreenAnnouncer();
+
+const optionLabel = (item: FilterOption): string =>
+  typeof item === "object" && item !== null ? item.label : String(item);
+
+const jurisdictionOption = computed<JurisdictionOption | undefined>(() => {
+  const first = currentJurisdictionFilter.value[0];
+  if (!first) return undefined;
+  const label = optionLabel(first);
+  return findJurisdictionByName(label);
+});
+
+function onJurisdictionChange(jurisdiction: JurisdictionOption | undefined) {
+  if (!jurisdiction) {
+    currentJurisdictionFilter.value = [];
+    return;
+  }
+  const next: FilterObjectOption = {
+    label: jurisdiction.label,
+    coldId: jurisdiction.coldId,
+  };
+  currentJurisdictionFilter.value = [next];
+}
+
+const themeValues = computed<string[]>({
+  get() {
+    return currentThemeFilter.value.map(optionLabel);
+  },
+  set(values) {
+    currentThemeFilter.value = values;
+  },
+});
+
+const typeValues = computed<string[]>({
+  get() {
+    return currentTypeFilter.value.map(optionLabel);
+  },
+  set(values) {
+    currentTypeFilter.value = values;
+  },
+});
 
 watch(
   () => [props.totalMatches, props.loading],
@@ -217,23 +311,31 @@ onMounted(async () => {
 </script>
 
 <style scoped>
-.filters-header {
+.search-results-header {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding-bottom: 12px;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: -24px;
 }
 
-.filters-header h2 {
-  margin: 0;
-  padding-bottom: 0;
+.entity-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.entity-filters__control {
+  min-width: 14rem;
+}
+
+.entity-filters__reset {
+  display: flex;
+  align-items: center;
 }
 
 .result-value-small {
   font-weight: 600;
-}
-
-.results-margin-fix {
-  margin-top: 1.5rem;
+  margin-top: 0.5rem;
 }
 </style>

--- a/frontend/app/components/ui/DetailDisplay.vue
+++ b/frontend/app/components/ui/DetailDisplay.vue
@@ -1,5 +1,7 @@
 <template>
   <article>
+    <SubmissionDisclaimer v-if="headerMode === 'new'" />
+
     <NotificationBanner
       v-if="showNotificationBanner"
       :notification-banner-message="notificationBannerMessage"
@@ -65,6 +67,7 @@ import { formatDate } from "@/utils/format";
 import MetaBand from "@/components/ui/MetaBand.vue";
 import ContributeBanner from "@/components/ui/ContributeBanner.vue";
 import NotificationBanner from "@/components/ui/NotificationBanner.vue";
+import SubmissionDisclaimer from "@/components/ui/SubmissionDisclaimer.vue";
 import LoadingCard from "@/components/layout/LoadingCard.vue";
 import InlineError from "@/components/ui/InlineError.vue";
 

--- a/frontend/app/components/ui/MetaBand.vue
+++ b/frontend/app/components/ui/MetaBand.vue
@@ -115,6 +115,54 @@
       </template>
       <template v-else>
         <UButton
+          v-if="newEntityHref && isLoggedIn"
+          :to="newEntityHref"
+          variant="ghost"
+          color="neutral"
+          size="xs"
+          leading-icon="i-material-symbols:add"
+          trailing-icon="i-material-symbols:add"
+          class="meta-btn"
+        >
+          New
+        </UButton>
+        <UPopover
+          v-else-if="newEntityHref"
+          :content="{ side: 'bottom', align: 'end', sideOffset: 8 }"
+        >
+          <UButton
+            variant="ghost"
+            color="neutral"
+            size="xs"
+            leading-icon="i-material-symbols:lock-outline"
+            trailing-icon="i-material-symbols:lock-outline"
+            class="meta-btn"
+            aria-label="Sign in to add new entry"
+          >
+            Submit data
+          </UButton>
+          <template #content>
+            <div class="login-popover">
+              <p class="login-popover__text">
+                A free CoLD account is required to keep the dataverse
+                trustworthy &mdash; we use it to prevent automated spam and
+                preserve the integrity of every record. Sign-up takes under a
+                minute.
+              </p>
+              <UButton
+                :to="loginRedirectHref"
+                external
+                block
+                color="primary"
+                size="sm"
+                leading-icon="i-material-symbols:login"
+              >
+                Sign in to continue
+              </UButton>
+            </div>
+          </template>
+        </UPopover>
+        <UButton
           v-if="showCite"
           variant="ghost"
           color="neutral"
@@ -225,6 +273,7 @@ import {
   getBasePathForCard,
   getIndexPathForCard,
   getLabelColorClass,
+  getNewPathForCard,
   getSingularLabel,
 } from "@/config/entityRegistry";
 
@@ -271,11 +320,31 @@ const emit = defineEmits<{
 
 const route = useRoute();
 const router = useRouter();
+const user = useUser();
 const { findJurisdictionByCode, findJurisdictionByName } =
   useJurisdictionLookup();
 
 const isCiteOpen = ref(false);
 const isNewMode = computed(() => props.headerMode === "new");
+const isLoggedIn = computed(() => !!user.value);
+
+const newEntityHref = computed(() => {
+  if (props.headerMode === "new") return undefined;
+  const cardType =
+    props.cardType || String(props.resultData?.sourceTable ?? "");
+  if (!cardType) return undefined;
+  const indexPath = getIndexPathForCard(cardType);
+  const newPath = getNewPathForCard(cardType);
+  if (!indexPath || !newPath) return undefined;
+  if (route.path.replace(/\/$/, "") !== indexPath) return undefined;
+  return newPath;
+});
+
+const loginRedirectHref = computed(() =>
+  newEntityHref.value
+    ? `/auth/login?returnTo=${encodeURIComponent(newEntityHref.value)}`
+    : undefined,
+);
 
 const searchParam = (value: string) =>
   encodeURIComponent(value).replace(/%20/g, "+");
@@ -477,6 +546,7 @@ const isVisible = computed(() => {
 const hasActions = computed(() => {
   if (props.headerMode === "new") return true;
   return (
+    !!newEntityHref.value ||
     props.showCite ||
     props.showJson ||
     props.showPrint ||
@@ -611,11 +681,11 @@ function printPage() {
   width: 10px;
 }
 
-.meta-band--compact .schip:hover .schip-tag {
+.meta-band--compact .schip:not(.schip--static):hover .schip-tag {
   width: 0;
 }
 
-.meta-band--compact .schip:hover .schip-affordance {
+.meta-band--compact .schip:not(.schip--static):hover .schip-affordance {
   width: 10px;
 }
 
@@ -644,149 +714,6 @@ function printPage() {
   flex-shrink: 0;
 }
 
-.schip {
-  --schip-color: var(--color-cold-purple);
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  padding: 2px 9px;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--schip-color) 8%, white);
-  color: color-mix(in srgb, var(--schip-color) 80%, black);
-  text-decoration: none;
-  white-space: nowrap;
-  border: 1px solid transparent;
-  transition:
-    background 0.15s ease,
-    border-color 0.15s ease,
-    color 0.15s ease;
-}
-
-.schip:not(.schip--static):hover {
-  background: color-mix(in srgb, var(--schip-color) 14%, white);
-  border-color: color-mix(in srgb, var(--schip-color) 30%, white);
-  color: color-mix(in srgb, var(--schip-color) 95%, black);
-}
-
-.schip--static {
-  cursor: default;
-}
-
-.schip--type {
-  --schip-color: var(--color-cold-purple);
-}
-
-.schip--type.label-court-decision {
-  --schip-color: var(--color-label-court-decision);
-}
-.schip--type.label-question {
-  --schip-color: var(--color-label-question);
-}
-.schip--type.label-instrument {
-  --schip-color: var(--color-label-instrument);
-}
-.schip--type.label-arbitration {
-  --schip-color: var(--color-label-arbitration);
-}
-.schip--type.label-literature {
-  --schip-color: var(--color-label-literature);
-}
-.schip--type.label-specialist {
-  --schip-color: var(--color-label-specialist);
-}
-.schip--type.label-jurisdiction {
-  --schip-color: var(--color-cold-night);
-}
-
-.schip--button {
-  cursor: pointer;
-  appearance: none;
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-.schip--jur {
-  --schip-color: var(--color-cold-night);
-}
-
-.schip--theme {
-  --schip-color: var(--color-cold-purple);
-}
-
-.schip-flag-wrap,
-.schip-arrow-wrap {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  width: 16px;
-  height: 11px;
-  overflow: hidden;
-  transition:
-    width 0.18s ease,
-    opacity 0.15s ease;
-}
-
-.schip-flag {
-  width: 16px;
-  height: 11px;
-  object-fit: contain;
-}
-
-.schip-arrow-wrap {
-  width: 0;
-  opacity: 0;
-  font-size: 12px;
-}
-
-.schip--jur:hover .schip-flag-wrap {
-  width: 0;
-  opacity: 0;
-}
-
-.schip--jur:hover .schip-arrow-wrap {
-  width: 16px;
-  opacity: 0.9;
-}
-
-.schip-tag,
-.schip-affordance {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  width: 11px;
-  font-size: 11px;
-  overflow: hidden;
-  transition:
-    width 0.15s ease,
-    opacity 0.15s ease;
-}
-
-.schip-tag {
-  opacity: 0.65;
-}
-
-.schip-affordance {
-  width: 0;
-  opacity: 0;
-}
-
-.schip:hover .schip-tag {
-  width: 0;
-  opacity: 0;
-}
-
-.schip:hover .schip-affordance {
-  width: 11px;
-  opacity: 0.9;
-}
-
 .meta-actions {
   display: flex;
   align-items: center;
@@ -806,6 +733,22 @@ function printPage() {
 
 :deep(.meta-btn:hover) {
   background: color-mix(in srgb, var(--color-cold-purple) 6%, white);
+}
+
+.login-popover {
+  width: 20rem;
+  max-width: calc(100vw - 1rem);
+  padding: 0.875rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.login-popover__text {
+  font-family: "DM Sans", sans-serif;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--color-cold-night-alpha);
 }
 </style>
 

--- a/frontend/app/components/ui/SubmissionDisclaimer.vue
+++ b/frontend/app/components/ui/SubmissionDisclaimer.vue
@@ -1,0 +1,523 @@
+<template>
+  <section class="sub-notes" aria-label="Submission notes">
+    <div class="sub-notes__decor" aria-hidden="true">
+      <div class="sub-notes__orb sub-notes__orb--purple" />
+      <div class="sub-notes__orb sub-notes__orb--green" />
+      <div class="sub-notes__grain" />
+    </div>
+
+    <header class="sub-notes__header">
+      <span class="sub-notes__eyebrow">
+        <span class="sub-notes__bullet" aria-hidden="true" />
+        Before you submit
+      </span>
+      <span class="sub-notes__counter" aria-hidden="true">
+        <span class="sub-notes__counter-num">{{ counterNum }}</span>
+        <span class="sub-notes__counter-label">{{ counterLabel }}</span>
+      </span>
+    </header>
+
+    <div class="sub-notes__list" role="list">
+      <component
+        :is="note.to ? NuxtLink : 'div'"
+        v-for="(note, idx) in resolvedNotes"
+        :key="`${idx}-${note.title}`"
+        :to="note.to"
+        role="listitem"
+        :class="['sub-notes__item', { 'sub-notes__item--link': !!note.to }]"
+      >
+        <span
+          :class="[
+            'sub-notes__icon',
+            `sub-notes__icon--${note.variant ?? 'purple'}`,
+          ]"
+          aria-hidden="true"
+        >
+          <UIcon :name="note.icon" />
+        </span>
+        <div class="sub-notes__body">
+          <div class="sub-notes__lede">
+            <span class="sub-notes__index" aria-hidden="true">
+              {{ String(idx + 1).padStart(2, "0") }}
+            </span>
+            <h3 class="sub-notes__title">{{ note.title }}</h3>
+            <span v-if="note.badge" class="sub-notes__badge">
+              <svg
+                class="sub-notes__badge-icon"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  d="M12 2L13.09 8.26L19 9L13.09 9.74L12 16L10.91 9.74L5 9L10.91 8.26L12 2Z"
+                />
+              </svg>
+              {{ note.badge }}
+            </span>
+          </div>
+          <p v-if="note.description" class="sub-notes__text">
+            {{ note.description }}
+          </p>
+        </div>
+        <span v-if="note.to" class="sub-notes__cta" aria-hidden="true">
+          <UIcon name="i-material-symbols:arrow-outward" />
+        </span>
+      </component>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, resolveComponent } from "vue";
+
+const NuxtLink = resolveComponent("NuxtLink");
+
+export interface SubmissionNote {
+  icon: string;
+  variant?: "purple" | "green" | "teal";
+  title: string;
+  description?: string;
+  to?: string;
+  badge?: string;
+}
+
+const props = withDefaults(
+  defineProps<{
+    showAutosaveNote?: boolean;
+    extraNotes?: SubmissionNote[];
+  }>(),
+  {
+    showAutosaveNote: true,
+    extraNotes: () => [],
+  },
+);
+
+const TERMS_NOTE: SubmissionNote = {
+  icon: "i-material-symbols:scale-outline",
+  variant: "purple",
+  title: "Submission terms",
+  description:
+    "Please ensure you have the necessary rights and permissions before submitting any content. All submissions are subject to review and may be edited for clarity and consistency.",
+};
+
+const AUTOSAVE_NOTE: SubmissionNote = {
+  icon: "i-material-symbols:save-clock-outline",
+  variant: "green",
+  title: "No autosave",
+  description:
+    "Please back up your data when working here. Leaving, closing or reloading this window will delete everything. Data is only saved after you submit.",
+};
+
+const resolvedNotes = computed<SubmissionNote[]>(() => {
+  const list: SubmissionNote[] = [TERMS_NOTE];
+  if (props.showAutosaveNote) list.push(AUTOSAVE_NOTE);
+  list.push(...props.extraNotes);
+  return list;
+});
+
+const counterNum = computed(() =>
+  String(resolvedNotes.value.length).padStart(2, "0"),
+);
+const counterLabel = computed(() =>
+  resolvedNotes.value.length === 1 ? "note" : "notes",
+);
+</script>
+
+<style scoped>
+.sub-notes {
+  position: relative;
+  overflow: hidden;
+  margin-bottom: 1.5rem;
+  border-radius: 1rem;
+  padding: 1.125rem 1.125rem 1.25rem;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--color-cold-cream) 38%, white),
+    color-mix(in srgb, white 96%, var(--color-cold-purple))
+  );
+  border: 1px solid
+    color-mix(in srgb, var(--color-cold-purple) 16%, transparent);
+  box-shadow: 0 1px 2px 0 rgb(15 0 53 / 0.04);
+}
+
+@media (min-width: 768px) {
+  .sub-notes {
+    padding: 1.375rem 1.625rem 1.5rem;
+  }
+}
+
+/* Decorative atmosphere */
+.sub-notes__decor {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  border-radius: inherit;
+}
+
+.sub-notes__orb {
+  position: absolute;
+  width: 14rem;
+  height: 14rem;
+  border-radius: 9999px;
+  filter: blur(64px);
+  opacity: 0.55;
+}
+
+.sub-notes__orb--purple {
+  top: -5rem;
+  left: -3.5rem;
+  background: radial-gradient(
+    circle,
+    color-mix(in srgb, var(--color-cold-purple) 28%, transparent),
+    transparent 70%
+  );
+}
+
+.sub-notes__orb--green {
+  bottom: -5rem;
+  right: -3.5rem;
+  background: radial-gradient(
+    circle,
+    color-mix(in srgb, var(--color-cold-green) 38%, transparent),
+    transparent 70%
+  );
+}
+
+.sub-notes__grain {
+  position: absolute;
+  inset: 0;
+  opacity: 0.18;
+  mix-blend-mode: multiply;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.04'/%3E%3C/svg%3E");
+  background-repeat: repeat;
+  background-size: 256px 256px;
+}
+
+/* Header band */
+.sub-notes__header {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 0.875rem;
+  margin-bottom: 0.25rem;
+  border-bottom: 1px dashed
+    color-mix(in srgb, var(--color-cold-night) 14%, transparent);
+}
+
+.sub-notes__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--color-cold-night);
+}
+
+.sub-notes__bullet {
+  width: 7px;
+  height: 7px;
+  border-radius: 9999px;
+  background: linear-gradient(
+    135deg,
+    var(--color-cold-purple),
+    var(--color-cold-green)
+  );
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-cold-purple) 14%, white);
+}
+
+.sub-notes__counter {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.375rem;
+  font-family: "IBM Plex Mono", monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--color-cold-night-alpha);
+}
+
+.sub-notes__counter-num {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-cold-night);
+  font-feature-settings: "tnum";
+}
+
+.sub-notes__counter-label {
+  font-size: 0.625rem;
+}
+
+/* Notes list */
+.sub-notes__list {
+  position: relative;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.sub-notes__item {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: flex-start;
+  gap: 0.875rem;
+  padding: 1rem 0;
+  text-decoration: none;
+  color: inherit;
+}
+
+.sub-notes__item + .sub-notes__item {
+  border-top: 1px solid
+    color-mix(in srgb, var(--color-cold-night) 6%, transparent);
+}
+
+@media (min-width: 768px) {
+  .sub-notes__item {
+    gap: 1.125rem;
+    padding: 1.125rem 0;
+  }
+}
+
+/* Linked notes get an interactive lift */
+.sub-notes__item--link {
+  cursor: pointer;
+  margin-left: -0.625rem;
+  margin-right: -0.625rem;
+  padding-left: 0.625rem;
+  padding-right: 0.625rem;
+  border-radius: 0.625rem;
+  transition:
+    background 180ms ease,
+    transform 180ms ease;
+}
+
+.sub-notes__item--link:hover {
+  background: color-mix(in srgb, white 60%, var(--color-cold-purple) 4%);
+}
+
+.sub-notes__item--link:hover .sub-notes__cta {
+  transform: translate(2px, -2px);
+  color: var(--color-cold-purple);
+}
+
+.sub-notes__item--link:focus-visible {
+  outline: 2px solid var(--color-cold-purple);
+  outline-offset: 2px;
+}
+
+/* Icon tile */
+.sub-notes__icon {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 0.625rem;
+  font-size: 1.125rem;
+  border: 1px solid transparent;
+  position: relative;
+  align-self: flex-start;
+  margin-top: 1px;
+}
+
+.sub-notes__icon::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: inset 0 1px 0 0 rgb(255 255 255 / 0.8);
+  pointer-events: none;
+}
+
+.sub-notes__icon--purple {
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--color-cold-purple) 16%, white),
+    color-mix(in srgb, var(--color-cold-purple) 6%, white)
+  );
+  border-color: color-mix(in srgb, var(--color-cold-purple) 24%, transparent);
+  color: var(--color-cold-purple);
+}
+
+.sub-notes__icon--green {
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--color-cold-green) 24%, white),
+    color-mix(in srgb, var(--color-cold-teal) 12%, white)
+  );
+  border-color: color-mix(in srgb, var(--color-cold-green) 32%, transparent);
+  color: color-mix(
+    in srgb,
+    var(--color-cold-teal) 90%,
+    var(--color-cold-night)
+  );
+}
+
+.sub-notes__icon--teal {
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--color-cold-teal) 18%, white),
+    color-mix(in srgb, var(--color-cold-purple) 6%, white)
+  );
+  border-color: color-mix(in srgb, var(--color-cold-teal) 28%, transparent);
+  color: var(--color-cold-teal);
+}
+
+/* Body */
+.sub-notes__body {
+  min-width: 0;
+}
+
+.sub-notes__lede {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.625rem;
+  margin-bottom: 0.25rem;
+}
+
+.sub-notes__index {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  color: var(--color-cold-purple);
+  font-feature-settings: "tnum";
+  flex-shrink: 0;
+}
+
+.sub-notes__title {
+  font-family: "DM Sans", sans-serif;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  line-height: 1.3;
+  letter-spacing: -0.005em;
+  color: var(--color-cold-night);
+  margin: 0;
+}
+
+.sub-notes__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  font-family: "DM Sans", sans-serif;
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: white;
+  background-image: linear-gradient(
+    135deg,
+    var(--color-cold-purple),
+    var(--color-cold-teal)
+  );
+  box-shadow: 0 2px 6px -2px
+    color-mix(in srgb, var(--color-cold-purple) 50%, transparent);
+}
+
+.sub-notes__badge-icon {
+  width: 0.625rem;
+  height: 0.625rem;
+}
+
+.sub-notes__text {
+  font-family: "DM Sans", sans-serif;
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  color: var(--color-cold-night-alpha);
+  margin: 0;
+  max-width: 64ch;
+  text-wrap: pretty;
+}
+
+.sub-notes__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 9999px;
+  font-size: 0.875rem;
+  color: var(--color-cold-night-alpha);
+  background: color-mix(in srgb, var(--color-cold-purple) 8%, white);
+  border: 1px solid
+    color-mix(in srgb, var(--color-cold-purple) 16%, transparent);
+  align-self: center;
+  transition:
+    transform 180ms ease,
+    color 180ms ease,
+    background 180ms ease;
+}
+
+/* Entrance choreography */
+@media (prefers-reduced-motion: no-preference) {
+  .sub-notes {
+    animation: subNotesEnter 0.55s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
+  .sub-notes__item {
+    animation: subNotesItemEnter 0.45s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
+  .sub-notes__item:nth-child(1) {
+    animation-delay: 120ms;
+  }
+  .sub-notes__item:nth-child(2) {
+    animation-delay: 200ms;
+  }
+  .sub-notes__item:nth-child(3) {
+    animation-delay: 280ms;
+  }
+  .sub-notes__item:nth-child(4) {
+    animation-delay: 360ms;
+  }
+}
+
+@keyframes subNotesEnter {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes subNotesItemEnter {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 480px) {
+  .sub-notes__header {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .sub-notes__counter {
+    margin-left: auto;
+  }
+
+  .sub-notes__icon {
+    width: 2rem;
+    height: 2rem;
+    font-size: 1rem;
+    border-radius: 0.5rem;
+  }
+}
+</style>

--- a/frontend/app/config/entityRegistry.ts
+++ b/frontend/app/config/entityRegistry.ts
@@ -169,6 +169,7 @@ export interface EntityConfig {
   excludeRelations?: string[];
   hasDetailPage?: boolean;
   hasIndexPage?: boolean;
+  hasNewPage?: boolean;
   variant?: string;
   searchCard?: SearchCardConfig;
 }
@@ -244,6 +245,7 @@ export const entityRegistry: Record<string, EntityConfig> = {
     titleKey: "caseTitle",
     process: processCourtDecision,
     contentComponentId: "CourtDecisionContent",
+    hasNewPage: true,
     variant: "court-decision",
     searchCard: {
       fields: [
@@ -323,6 +325,7 @@ export const entityRegistry: Record<string, EntityConfig> = {
     titleKey: "title",
     process: processLiterature,
     contentComponentId: "LiteratureContent",
+    hasNewPage: true,
     variant: "literature",
     searchCard: {
       fields: [
@@ -367,6 +370,7 @@ export const entityRegistry: Record<string, EntityConfig> = {
     titleKey: "titleInEnglish",
     process: processDomesticInstrument,
     contentComponentId: "DomesticInstrumentContent",
+    hasNewPage: true,
     variant: "instrument",
     searchCard: {
       fields: [
@@ -397,6 +401,7 @@ export const entityRegistry: Record<string, EntityConfig> = {
     titleKey: "title",
     process: processRegionalInstrument,
     contentComponentId: "RegionalInstrumentContent",
+    hasNewPage: true,
     variant: "instrument",
     searchCard: {
       fields: [
@@ -418,6 +423,7 @@ export const entityRegistry: Record<string, EntityConfig> = {
     titleKey: "name",
     process: processInternationalInstrument,
     contentComponentId: "InternationalInstrumentContent",
+    hasNewPage: true,
     variant: "instrument",
     searchCard: {
       fields: [
@@ -590,6 +596,14 @@ export function getIndexPathForCard(cardType: string): string | undefined {
   const config = entityRegistry[basePath];
   if (config?.hasIndexPage === false) return undefined;
   return basePath;
+}
+
+export function getNewPathForCard(cardType: string): string | undefined {
+  const basePath = getBasePathForCard(cardType);
+  if (!basePath) return undefined;
+  const config = entityRegistry[basePath];
+  if (!config?.hasNewPage) return undefined;
+  return `${basePath}/new`;
 }
 
 const VARIANT_TO_LABEL_CLASS: Record<string, string> = {

--- a/frontend/app/pages/arbitral-award/index.vue
+++ b/frontend/app/pages/arbitral-award/index.vue
@@ -12,6 +12,8 @@
           v-model:jurisdiction="selectedJurisdiction"
           v-model:theme="selectedTheme"
           :filters="['jurisdiction', 'theme']"
+          :count="data?.total"
+          :loading="isFetching"
         />
 
         <EntityListTable
@@ -22,7 +24,7 @@
           :rows="rows"
           link-base="/arbitral-award"
           :total="data?.total"
-          :loading="isLoading"
+          :loading="isFetching"
         />
       </div>
     </template>
@@ -60,7 +62,7 @@ watch([jurisdictionCode, selectedTheme], () => {
   page.value = 1;
 });
 
-const { data, isLoading } = useEntityList("arbitral-awards", {
+const { data, isLoading, isFetching } = useEntityList("arbitral-awards", {
   page,
   jurisdiction: jurisdictionCode,
   theme: selectedTheme,

--- a/frontend/app/pages/arbitral-institution/index.vue
+++ b/frontend/app/pages/arbitral-institution/index.vue
@@ -16,7 +16,7 @@
           :rows="rows"
           link-base="/arbitral-institution"
           :total="data?.total"
-          :loading="isLoading"
+          :loading="isFetching"
         />
       </div>
     </template>
@@ -41,7 +41,7 @@ const resultData = null;
 const orderBy = ref<string | undefined>(undefined);
 const orderDir = ref<"asc" | "desc" | undefined>(undefined);
 
-const { data, isLoading } = useEntityList("arbitral-institutions", {
+const { data, isLoading, isFetching } = useEntityList("arbitral-institutions", {
   page,
   orderBy,
   orderDir,

--- a/frontend/app/pages/arbitral-rule/index.vue
+++ b/frontend/app/pages/arbitral-rule/index.vue
@@ -16,7 +16,7 @@
           :rows="rows"
           link-base="/arbitral-rule"
           :total="data?.total"
-          :loading="isLoading"
+          :loading="isFetching"
         />
       </div>
     </template>
@@ -41,7 +41,7 @@ const resultData = null;
 const orderBy = ref<string | undefined>(undefined);
 const orderDir = ref<"asc" | "desc" | undefined>(undefined);
 
-const { data, isLoading } = useEntityList("arbitral-rules", {
+const { data, isLoading, isFetching } = useEntityList("arbitral-rules", {
   page,
   orderBy,
   orderDir,

--- a/frontend/app/pages/court-decision/index.vue
+++ b/frontend/app/pages/court-decision/index.vue
@@ -12,6 +12,8 @@
           v-model:jurisdiction="selectedJurisdiction"
           v-model:theme="selectedTheme"
           :filters="['jurisdiction', 'theme']"
+          :count="data?.total"
+          :loading="isFetching"
         />
 
         <EntityListTable
@@ -22,7 +24,7 @@
           :rows="rows"
           link-base="/court-decision"
           :total="data?.total"
-          :loading="isLoading"
+          :loading="isFetching"
         />
       </div>
     </template>
@@ -69,7 +71,7 @@ watch([jurisdictionCode, selectedTheme, caseRank], () => {
   page.value = 1;
 });
 
-const { data, isLoading } = useEntityList("court-decisions", {
+const { data, isLoading, isFetching } = useEntityList("court-decisions", {
   page,
   jurisdiction: jurisdictionCode,
   theme: selectedTheme,

--- a/frontend/app/pages/court-decision/new.vue
+++ b/frontend/app/pages/court-decision/new.vue
@@ -1,24 +1,9 @@
 <template>
-  <div class="py-12">
-    <!-- Page Header -->
-    <PageHero
-      title="Case Analyzer"
-      subtitle="Upload a court decision and let AI automatically extract jurisdiction, choice of law provisions, and key PIL elements."
-      badge="AI-Powered"
-    >
-      <template #content>
-        <NuxtLink
-          to="/court-decision/my-analyses"
-          class="text-cold-purple mt-4 inline-flex items-center gap-1 text-sm hover:underline"
-        >
-          <UIcon name="i-heroicons-document-text" class="h-4 w-4" />
-          View My Analyses
-        </NuxtLink>
-      </template>
-      <template #illustration>
-        <AnalyzerIllustration />
-      </template>
-    </PageHero>
+  <div>
+    <SubmissionDisclaimer
+      :show-autosave-note="false"
+      :extra-notes="caseAnalyzerNotes"
+    />
 
     <!-- Error Display -->
     <UAlert
@@ -154,10 +139,30 @@ import FileUploadCard from "@/components/case-analyzer/FileUploadCard.vue";
 import JurisdictionConfirmCard from "@/components/case-analyzer/JurisdictionConfirmCard.vue";
 import AnalysisReviewForm from "@/components/case-analyzer/AnalysisReviewForm.vue";
 import AnalysisStepTracker from "@/components/case-analyzer/AnalysisStepTracker.vue";
-import PageHero from "@/components/ui/PageHero.vue";
-import AnalyzerIllustration from "@/components/case-analyzer/AnalyzerIllustration.vue";
+import SubmissionDisclaimer, {
+  type SubmissionNote,
+} from "@/components/ui/SubmissionDisclaimer.vue";
 
 useHead({ title: "AI Case Analyzer — CoLD" });
+
+const caseAnalyzerNotes: SubmissionNote[] = [
+  {
+    icon: "i-material-symbols:auto-awesome-outline",
+    variant: "teal",
+    title: "Case Analyzer",
+    badge: "AI-Powered",
+    description:
+      "Upload a court decision and let AI automatically extract jurisdiction, choice of law provisions, and key PIL elements.",
+  },
+  {
+    icon: "i-material-symbols:list-alt-outline",
+    variant: "purple",
+    title: "View my analyses",
+    description:
+      "Pick up where you left off — past uploads and drafts stay accessible from your account.",
+    to: "/court-decision/my-analyses",
+  },
+];
 
 const user = useUser();
 const route = useRoute();

--- a/frontend/app/pages/domestic-instrument/index.vue
+++ b/frontend/app/pages/domestic-instrument/index.vue
@@ -11,6 +11,8 @@
         <EntityListFilters
           v-model:jurisdiction="selectedJurisdiction"
           :filters="['jurisdiction']"
+          :count="data?.total"
+          :loading="isFetching"
         />
 
         <EntityListTable
@@ -21,7 +23,7 @@
           :rows="rows"
           link-base="/domestic-instrument"
           :total="data?.total"
-          :loading="isLoading"
+          :loading="isFetching"
         />
       </div>
     </template>
@@ -58,7 +60,7 @@ watch(jurisdictionCode, () => {
   page.value = 1;
 });
 
-const { data, isLoading } = useEntityList("domestic-instruments", {
+const { data, isLoading, isFetching } = useEntityList("domestic-instruments", {
   page,
   jurisdiction: jurisdictionCode,
   orderBy,

--- a/frontend/app/pages/domestic-instrument/new.vue
+++ b/frontend/app/pages/domestic-instrument/new.vue
@@ -5,9 +5,6 @@
       :loading="false"
       :data="null"
       header-mode="new"
-      :show-notification-banner="true"
-      :notification-banner-message="notificationBannerMessage"
-      :icon="'i-material-symbols:warning-outline'"
       @open-save-modal="openSaveModal"
       @open-cancel-modal="showCancelModal = true"
     >
@@ -327,8 +324,6 @@ const saveModalErrors = ref<Record<string, string>>({});
 const router = useRouter();
 const showSaveModal = ref(false);
 const showCancelModal = ref(false);
-const notificationBannerMessage =
-  "Please back up your data when working here. Leaving, closing or reloading this window will delete everything. Data is only saved after you submit.";
 
 useHead({ title: "New Domestic Instrument — CoLD" });
 

--- a/frontend/app/pages/international-instrument/[...slug].vue
+++ b/frontend/app/pages/international-instrument/[...slug].vue
@@ -5,9 +5,6 @@
       :loading="loading"
       :data="null"
       header-mode="new"
-      :show-notification-banner="true"
-      :notification-banner-message="notificationBannerMessage"
-      :icon="'i-material-symbols:warning-outline'"
       @open-save-modal="openSaveModal"
       @open-cancel-modal="showCancelModal = true"
     >
@@ -167,8 +164,6 @@ const errors = ref<Record<string, string>>({});
 const saveModalErrors = ref<Record<string, string>>({});
 const showSaveModal = ref(false);
 const showCancelModal = ref(false);
-const notificationBannerMessage =
-  "Please back up your data when working here. Closing or reloading this window will delete everything. Data is only saved after you submit.";
 const instrumentApiId = ref<string | null>(null);
 
 const formSchema = z.object({

--- a/frontend/app/pages/international-instrument/index.vue
+++ b/frontend/app/pages/international-instrument/index.vue
@@ -16,7 +16,7 @@
           :rows="rows"
           link-base="/international-instrument"
           :total="data?.total"
-          :loading="isLoading"
+          :loading="isFetching"
         />
       </div>
     </template>
@@ -41,11 +41,14 @@ const resultData = null;
 const orderBy = ref<string | undefined>(undefined);
 const orderDir = ref<"asc" | "desc" | undefined>(undefined);
 
-const { data, isLoading } = useEntityList("international-instruments", {
-  page,
-  orderBy,
-  orderDir,
-});
+const { data, isLoading, isFetching } = useEntityList(
+  "international-instruments",
+  {
+    page,
+    orderBy,
+    orderDir,
+  },
+);
 
 const rows = computed(() =>
   (data.value?.items ?? []).map((item) => ({

--- a/frontend/app/pages/international-instrument/new.vue
+++ b/frontend/app/pages/international-instrument/new.vue
@@ -5,9 +5,6 @@
       :loading="false"
       :data="null"
       header-mode="new"
-      :show-notification-banner="true"
-      :notification-banner-message="notificationBannerMessage"
-      :icon="'i-material-symbols:warning-outline'"
       @open-save-modal="openSaveModal"
       @open-cancel-modal="showCancelModal = true"
     >
@@ -128,8 +125,6 @@ const saveModalErrors = ref<Record<string, string>>({});
 const router = useRouter();
 const showSaveModal = ref(false);
 const showCancelModal = ref(false);
-const notificationBannerMessage =
-  "Please back up your data when working here. Leaving, closing or reloading this window will delete everything. Data is only saved after you submit.";
 
 useHead({ title: "New International Instrument — CoLD" });
 

--- a/frontend/app/pages/literature/index.vue
+++ b/frontend/app/pages/literature/index.vue
@@ -8,7 +8,12 @@
     <template #full-width>
       <div class="gradient-top-border" />
       <div class="w-full px-6 py-6">
-        <EntityListFilters v-model:theme="selectedTheme" :filters="['theme']" />
+        <EntityListFilters
+          v-model:theme="selectedTheme"
+          :filters="['theme']"
+          :count="data?.total"
+          :loading="isFetching"
+        />
 
         <EntityListTable
           v-model:page="page"
@@ -18,7 +23,7 @@
           :rows="rows"
           link-base="/literature"
           :total="data?.total"
-          :loading="isLoading"
+          :loading="isFetching"
         >
           <template #cell-title="{ row }">
             <span class="result-value-small entity-list__cell">
@@ -62,7 +67,7 @@ watch(selectedTheme, () => {
   page.value = 1;
 });
 
-const { data, isLoading } = useEntityList("literature", {
+const { data, isLoading, isFetching } = useEntityList("literature", {
   page,
   theme: selectedTheme,
   orderBy,

--- a/frontend/app/pages/literature/new.vue
+++ b/frontend/app/pages/literature/new.vue
@@ -5,9 +5,6 @@
       :loading="false"
       :data="null"
       header-mode="new"
-      :show-notification-banner="true"
-      :notification-banner-message="notificationBannerMessage"
-      :icon="'i-material-symbols:warning-outline'"
       @open-save-modal="openSaveModal"
       @open-cancel-modal="showCancelModal = true"
     >
@@ -242,8 +239,6 @@ const saveModalErrors = ref<Record<string, string>>({});
 const router = useRouter();
 const showSaveModal = ref(false);
 const showCancelModal = ref(false);
-const notificationBannerMessage =
-  "Please back up your data when working here. Leaving, closing or reloading this window will delete everything. Data is only saved after you submit.";
 
 useHead({ title: "New Literature — CoLD" });
 

--- a/frontend/app/pages/regional-instrument/index.vue
+++ b/frontend/app/pages/regional-instrument/index.vue
@@ -16,7 +16,7 @@
           :rows="rows"
           link-base="/regional-instrument"
           :total="data?.total"
-          :loading="isLoading"
+          :loading="isFetching"
         />
       </div>
     </template>
@@ -41,7 +41,7 @@ const resultData = null;
 const orderBy = ref<string | undefined>(undefined);
 const orderDir = ref<"asc" | "desc" | undefined>(undefined);
 
-const { data, isLoading } = useEntityList("regional-instruments", {
+const { data, isLoading, isFetching } = useEntityList("regional-instruments", {
   page,
   orderBy,
   orderDir,

--- a/frontend/app/pages/regional-instrument/new.vue
+++ b/frontend/app/pages/regional-instrument/new.vue
@@ -5,9 +5,6 @@
       :loading="false"
       :data="null"
       header-mode="new"
-      :show-notification-banner="true"
-      :notification-banner-message="notificationBannerMessage"
-      :icon="'i-material-symbols:warning-outline'"
       @open-save-modal="openSaveModal"
       @open-cancel-modal="showCancelModal = true"
     >
@@ -129,8 +126,6 @@ const router = useRouter();
 defineEmits(["close-cancel-modal", "close-save-modal"]);
 const showSaveModal = ref(false);
 const showCancelModal = ref(false);
-const notificationBannerMessage =
-  "Please back up your data when working here. Leaving, closing or reloading this window will delete everything. Data is only saved after you submit.";
 
 useHead({ title: "New Regional Instrument — CoLD" });
 

--- a/frontend/app/pages/specialist/index.vue
+++ b/frontend/app/pages/specialist/index.vue
@@ -16,7 +16,7 @@
           :rows="rows"
           link-base="/specialist"
           :total="data?.total"
-          :loading="isLoading"
+          :loading="isFetching"
         />
       </div>
     </template>
@@ -41,7 +41,7 @@ const resultData = null;
 const orderBy = ref<string | undefined>(undefined);
 const orderDir = ref<"asc" | "desc" | undefined>(undefined);
 
-const { data, isLoading } = useEntityList("specialists", {
+const { data, isLoading, isFetching } = useEntityList("specialists", {
   page,
   orderBy,
   orderDir,

--- a/frontend/content/disclaimer.md
+++ b/frontend/content/disclaimer.md
@@ -5,7 +5,7 @@ title: Disclaimer — CoLD
 ## 1. Copyright and Licensing Disclaimer
 
 **Copyright:**  
-2025 Choice of Law Dataverse
+2026 Choice of Law Dataverse
 
 **License:**  
 The data published on this website is made available under the terms of the Creative Commons Attribution-ShareAlike (CC BY-SA) license. You are free to reuse, distribute, remix, adapt, and build upon the data, even commercially, provided you clearly attribute the original source and distribute any derivative works under the same or a compatible license.


### PR DESCRIPTION
## Summary

- **Search & filter schips**: chip-styled jurisdiction/theme filter values across entity list pages, with inline result counts and a loading/aria-busy state on the filters bar.
- **Footer redesign**: replaces the heavy "stay connected" tile section with an academic meta strip — citation, CC BY-SA license, SNF Project No. 215469 (2023–2026), University of Lucerne, plus compact social icons and a Contact link.
- **SubmissionDisclaimer**: extracted into a reusable component used by submission pages (Literature, Domestic/Regional/International Instruments, Court Decision); fixes a non-working "View my analyses" link by switching the dynamic component from the string `'NuxtLink'` to a `resolveComponent('NuxtLink')` reference.
- **Cross-page polish**: MetaBand, SearchResultsHeader, JurisdictionSelectMenu, EntityListTable, DetailDisplay, and the various listing/new pages get layout, spacing, and styling refinements.

## Test plan

- [ ] Visit each entity listing page (court-decision, literature, domestic/regional/international-instrument, arbitral-award/institution/rule, specialist) and verify schip filter values, result count, loading state, and "Clear filters".
- [ ] Open the footer on every page and confirm the new meta strip renders, links work (CC BY-SA, /disclaimer, /about/supporters, Contact), and socials open in a new tab.
- [ ] On `/court-decision/new`, click the "View my analyses" disclaimer note and confirm it navigates to `/court-decision/my-analyses`.
- [ ] Confirm vertical spacing of the disclaimer matches other `new.vue` pages (no extra `py-12` gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)