### PR TITLE
fix(frontend): hide New button inside entity drawer

### DIFF
--- a/frontend/app/components/entity/EntityDrawer.vue
+++ b/frontend/app/components/entity/EntityDrawer.vue
@@ -58,6 +58,7 @@
             :show-cite="false"
             :show-json="false"
             :show-print="false"
+            :show-new="false"
             compact
           />
         </header>

--- a/frontend/app/components/ui/MetaBand.vue
+++ b/frontend/app/components/ui/MetaBand.vue
@@ -115,7 +115,7 @@
       </template>
       <template v-else>
         <UButton
-          v-if="newEntityHref && isLoggedIn"
+          v-if="showNew && newEntityHref && isLoggedIn"
           :to="newEntityHref"
           variant="ghost"
           color="neutral"
@@ -127,7 +127,7 @@
           New
         </UButton>
         <UPopover
-          v-else-if="newEntityHref"
+          v-else-if="showNew && newEntityHref"
           :content="{ side: 'bottom', align: 'end', sideOffset: 8 }"
         >
           <UButton
@@ -293,6 +293,7 @@ const props = withDefaults(
     showCite?: boolean;
     showJson?: boolean;
     showPrint?: boolean;
+    showNew?: boolean;
     entityType?: string;
     entityId?: string;
     entityTitle?: string;
@@ -307,6 +308,7 @@ const props = withDefaults(
     showCite: true,
     showJson: true,
     showPrint: true,
+    showNew: true,
     entityType: "",
     entityId: "",
     entityTitle: "",
@@ -546,7 +548,7 @@ const isVisible = computed(() => {
 const hasActions = computed(() => {
   if (props.headerMode === "new") return true;
   return (
-    !!newEntityHref.value ||
+    (props.showNew && !!newEntityHref.value) ||
     props.showCite ||
     props.showJson ||
     props.showPrint ||


### PR DESCRIPTION
## Summary
- Adds a `showNew` prop to `MetaBand` (default `true`) that gates both the `New` button and its logged-out `Submit data` popover variant.
- `EntityDrawer` passes `:show-new="false"` so the action never appears in the drawer header.

## Test plan
- [x] `pnpm run check` (prettier, eslint, vue-tsc, vitest) passes
- [ ] Open an entity drawer from a list page and confirm no `New` / `Submit data` button is rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)