### PR TITLE
fix(frontend): render jurisdictions relation panel on specialist pages

### DIFF
--- a/frontend/app/components/entity/EntityContent.vue
+++ b/frontend/app/components/entity/EntityContent.vue
@@ -97,7 +97,6 @@ const resolvedRelations = computed<ResolvedRelation[]>(() => {
   if (!relData) return [];
   const exclude = new Set(entityConfig.value?.excludeRelations ?? []);
   return Object.entries(RELATION_RENDERERS)
-    .filter(([key]) => !exclude.has(key))
     .map(([key, config]) => {
       const rawItems = relData[key] ?? [];
       const sorted = [...rawItems].sort(
@@ -111,7 +110,11 @@ const resolvedRelations = computed<ResolvedRelation[]>(() => {
         items: sorted.map(mapRelationToItem).filter((item) => item.id),
       };
     })
-    .filter((s) => s.items.length > 0);
+    .filter((s) => {
+      if (s.items.length === 0) return false;
+      if (!exclude.has(s.key)) return true;
+      return s.key === "jurisdictions" && s.items.length > 1;
+    });
 });
 
 function shouldDisplayValue(value: unknown): boolean {

--- a/frontend/app/config/entityRegistry.ts
+++ b/frontend/app/config/entityRegistry.ts
@@ -69,6 +69,11 @@ export const RELATION_RENDERERS: Record<string, RelationRendererConfig> = {
     basePath: "/specialist",
     variant: "specialist",
   },
+  jurisdictions: {
+    label: "Jurisdictions",
+    basePath: "/jurisdiction",
+    variant: "jurisdiction",
+  },
   questions: {
     label: "Questions",
     basePath: "/question",
@@ -245,6 +250,7 @@ export const entityRegistry: Record<string, EntityConfig> = {
     titleKey: "caseTitle",
     process: processCourtDecision,
     contentComponentId: "CourtDecisionContent",
+    excludeRelations: ["jurisdictions"],
     hasNewPage: true,
     variant: "court-decision",
     searchCard: {
@@ -370,6 +376,7 @@ export const entityRegistry: Record<string, EntityConfig> = {
     titleKey: "titleInEnglish",
     process: processDomesticInstrument,
     contentComponentId: "DomesticInstrumentContent",
+    excludeRelations: ["jurisdictions"],
     hasNewPage: true,
     variant: "instrument",
     searchCard: {
@@ -461,6 +468,7 @@ export const entityRegistry: Record<string, EntityConfig> = {
     fieldOrder: ["institution", "abbreviation"],
     titleKey: "institution",
     process: processArbitralInstitution,
+    excludeRelations: ["jurisdictions"],
     variant: "arbitration",
   },
   "/arbitral-award": {
@@ -483,6 +491,7 @@ export const entityRegistry: Record<string, EntityConfig> = {
     },
     titleKey: "caseNumber",
     process: processArbitralAward,
+    excludeRelations: ["jurisdictions"],
     variant: "arbitration",
     searchCard: {
       fields: [
@@ -535,6 +544,7 @@ export const entityRegistry: Record<string, EntityConfig> = {
     },
     titleKey: "article",
     process: processDomesticLegalProvision,
+    excludeRelations: ["jurisdictions"],
     hasDetailPage: false,
   },
   "/regional-legal-provision": {


### PR DESCRIPTION
## Summary
- Added `jurisdictions` to `RELATION_RENDERERS` so the panel actually renders; previously it was missing entirely, which is why specialists never showed their linked jurisdictions even though the API returned them.
- For entities whose MetaBand header already shows a primary-jurisdiction chip (court decisions, domestic instruments, domestic legal provisions, arbitral awards, arbitral institutions), the panel now renders only when there are 2+ linked jurisdictions, so the single-jurisdiction case stays in the chip.

## Test plan
- [ ] Specialist with multiple jurisdictions (e.g. SP-6) shows JURISDICTIONS list
- [ ] Specialist with one jurisdiction (e.g. SP-63) shows JURISDICTIONS list (no chip exists in header for specialists)
- [ ] Court decision with one linked jurisdiction shows the chip but no body panel
- [ ] Court decision with multiple linked jurisdictions shows both chip and panel
- [ ] `pnpm run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)