### PR TITLE
refactor(frontend): align hero badge inline with title via flex row

### DIFF
--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -4,43 +4,50 @@
   >
     <div class="animate-fade-scale-in col-span-12">
       <div
-        class="hero-gradient hero-stack rounded-2xl px-3 py-8 md:px-10 md:py-14"
+        class="hero-gradient hero-stack w-full rounded-2xl px-3 py-8 md:px-10 md:py-14"
       >
-        <h1
-          class="hero-title text-[40px] leading-[1.02] font-bold text-pretty sm:text-[64px] md:text-[80px]"
+        <div
+          class="space-between align-items-center flex w-full flex-grow flex-col md:flex-row"
         >
-          Choice of Law Dataverse
-        </h1>
-
-        <div class="hero-bottom">
-          <h2 class="hero-subtitle text-lg font-medium text-pretty">
-            Navigate private international law issues with precision.
-            <NuxtLink class="hero-link" to="/about" variant="link">
-              What&nbsp;is&nbsp;CoLD?
-            </NuxtLink>
-          </h2>
-
-          <UTooltip
-            text="Winner of Swiss National ORD Prize 2025 for Legal Sciences"
-          >
-            <a
-              href="https://ord.swiss-academies.ch/news/swiss-national-ord-prize-2025-for-legal-and-environmental-sciences"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="hero-badge"
+          <div class="flex flex-col gap-2">
+            <h1
+              class="hero-title text-[40px] leading-[1.02] font-bold text-pretty sm:text-[64px] md:text-[80px]"
             >
-              <img
-                src="https://assets.cold.global/assets/Prix-ORD-DEF_2025.png"
-                alt="Swiss National ORD Prize 2025"
-                class="hero-badge-img"
-                width="64"
-                height="67"
-                loading="lazy"
-                decoding="async"
-              />
-              <span class="hero-badge-text">Swiss National ORD Prize 2025</span>
-            </a>
-          </UTooltip>
+              Choice of Law Dataverse
+            </h1>
+
+            <div class="hero-bottom">
+              <h2 class="hero-subtitle text-lg font-medium text-pretty">
+                Navigate private international law issues with precision.
+                <NuxtLink class="hero-link" to="/about" variant="link">
+                  What&nbsp;is&nbsp;CoLD?
+                </NuxtLink>
+              </h2>
+            </div>
+          </div>
+
+          <div class="ml-auto flex items-center">
+            <UTooltip
+              text="Winner of Swiss National ORD Prize 2025 for Legal Sciences"
+            >
+              <a
+                href="https://ord.swiss-academies.ch/news/swiss-national-ord-prize-2025-for-legal-and-environmental-sciences"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="hero-badge"
+              >
+                <img
+                  src="https://assets.cold.global/assets/Prix-ORD-DEF_2025.png"
+                  alt="Swiss National ORD Prize 2025"
+                  class="hero-badge-img"
+                  width="64"
+                  height="67"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </a>
+            </UTooltip>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/content/open_educational_resources.md
+++ b/frontend/content/open_educational_resources.md
@@ -8,21 +8,21 @@ This <a href="https://global.oup.com/academic/product/choice-of-law-in-internati
     src="https://assets.cold.global/assets/external_link.svg"
     alt="external link"
     class="external-link-icon"
-  /></a> is the main output of the previous research project, <a href=”https://data.snf.ch/grants/grant/179515” target=”_blank”>”The Hague Principles and Beyond”<img
-src=”https://assets.cold.global/assets/external_link.svg”
-alt=”external link”
-class=”external-link-icon”
+  /></a> is the main output of the previous research project, <a href="https://data.snf.ch/grants/grant/179515" target="_blank">”The Hague Principles and Beyond”<img
+src="https://assets.cold.global/assets/external_link.svg"
+alt="external link"
+class="external-link-icon"
 /></a>. It contains over sixty reports dealing with the regulation of choice of law in a significant number of jurisdictions around the world and a general report. The book has been applauded by the academic community, and it is regarded as a definitive reference guide to the key choice of law principles on international contracts.
-<a href=”https://fdslive.oup.com/www.oup.com/academic/pdf/13/9780198840107_chapter1.pdf” target=”_blank”>Read the General Comparative Report<img
-src=”https://assets.cold.global/assets/external_link.svg”
-alt=”external link”
-class=”external-link-icon”
+<a href="https://fdslive.oup.com/www.oup.com/academic/pdf/13/9780198840107_chapter1.pdf" target="_blank">Read the General Comparative Report<img
+src="https://assets.cold.global/assets/external_link.svg"
+alt="external link"
+class="external-link-icon"
 /></a>.
 
 ## ‌Uniform Law Review
 
-Volume 22, Issue 2, June 2017 - special issue on the HCCH Principles (<a href=”https://academic.oup.com/ulr/issue/22/2” target=”_blank”>available through paywall<img
-    src=”https://assets.cold.global/assets/external_link.svg”
+Volume 22, Issue 2, June 2017 - special issue on the HCCH Principles (<a href="https://academic.oup.com/ulr/issue/22/2" target="_blank">available through paywall<img
+    src="https://assets.cold.global/assets/external_link.svg"
     alt="external link"
     class="external-link-icon"
   /></a> (Open Access).


### PR DESCRIPTION
## Summary

- Restructures the homepage hero section to use a flex row layout, placing the ORD Prize badge inline beside the title and subtitle instead of below them.
- Removes the redundant badge text label beneath the badge image.
- Fixes indentation whitespace in `open_educational_resources.md`.

## Test plan

- [ ] Visit the homepage and verify the ORD badge appears to the right of the title/subtitle on desktop, and stacked below on mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)