### PR TITLE
chore(frontend): add author credit to footer and package.json

### DIFF
--- a/frontend/app/components/layout/Footer.vue
+++ b/frontend/app/components/layout/Footer.vue
@@ -194,6 +194,18 @@ const currentYear = new Date().getFullYear();
           </div>
         </div>
       </div>
+
+      <p class="footer-credit mt-8 text-center text-xs text-gray-400">
+        site by
+        <a
+          href="https://marcosmesser.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="footer-meta__link text-xs"
+        >
+          Marcos Messer
+        </a>
+      </p>
     </div>
   </footer>
 </template>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,10 @@
 {
   "name": "nuxt-app",
+  "author": {
+    "name": "Marcos Messer",
+    "email": "git@marcosmesser.com",
+    "url": "https://marcosmesser.com"
+  },
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.3",


### PR DESCRIPTION
## Summary

- Adds a "site by Marcos Messer" credit link to the footer, centered below the meta strip
- Adds `author` field (object form) to `package.json` with name, email, and URL

## Test plan

- [ ] Verify the footer credit renders and links to https://marcosmesser.com
- [ ] Verify `package.json` parses correctly with the new `author` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)